### PR TITLE
chore: rename to serverservice and add migrate and version subcommands

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,7 +25,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -28,46 +28,32 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
-
-      - name: Start test database
-        run: make docker-up
-
-      - name: Install goose for database migrations
-        run: go install github.com/pressly/goose/cmd/goose@v2.7.0
+          go-version: '1.17'
 
       - name: Install cockroach binary
         run: curl https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v21.1.7.linux-amd64/cockroach /usr/local/bin/
+
+      - name: Start test database
+        run: cockroach start-single-node --insecure --background
 
       - name: Create test DB
         run: make test-database
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
-
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.41
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          version: v1.42
           args: --timeout=5m
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
 
       - name: Run go tests for generated models code
         run: go test -race ./internal/models
 
       # Don't include the models test that we tested above already. We don't want to calculate the test coverage from these into the app since we can't affect it
       - name: Run go tests and generate coverage report
-        run: HOLLOW_DCIM_TEST_DB="host=localhost port=26257 user=root sslmode=disable dbname=hollow_dcim_test" go test -race -coverprofile=coverage.txt -covermode=atomic -tags testtools -p 1 `go list ./... | grep -v internal/models`
+        run: SERVERSERVICE_DB_URI="host=localhost port=26257 user=root sslmode=disable dbname=serverservice_test" go test -race -coverprofile=coverage.txt -covermode=atomic -tags testtools -p 1 `go list ./... | grep -v internal/models`
 
       - name: Stop test database
-        run: make docker-down
+        run: cockroach quit --insecure --host=localhost:26257
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 
 linters-settings:
   goimports:
-    local-prefixes: go.hollow.sh/dcim
+    local-prefixes: go.hollow.sh/serverservice
   gofumpt:
     extra-rules: true
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: hollow-dcim
+project_name: serverservice
 before:
   hooks:
     - go mod download
@@ -50,7 +50,5 @@ changelog:
 dockers:
   -
     image_templates:
-      - "ghcr.io/metal-toolbox/{{.ProjectName}}:{{ .Tag }}"
+      - "ghcr.io/metal-toolbox/hollow-{{.ProjectName}}:{{ .Tag }}"
     dockerfile: Dockerfile
-    extra_files:
-    - db/migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,13 @@
-FROM golang:1.17 as builder
-
-# Build the goose binary
-RUN CGO_ENABLED=0 GOOS=linux go install github.com/pressly/goose/cmd/goose@v2.7.0
-
-# Use the official Alpine image for a lean production container.
-# https://hub.docker.com/_/alpine
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3
+FROM alpine:3 as alpine
 RUN apk add --no-cache ca-certificates
 
-# Copy the binary to the production image from the builder stage.
-COPY hollow-dcim /hollow-dcim
+FROM scratch
+# Copy ca-certs from alpine
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Copy goose and database migration files
-COPY --from=builder /go/bin/goose /goose
-COPY db/migrations /db-migrations
+# Copy the binary that goreleaser built
+COPY serverservice /serverservice
 
 # Run the web service on container startup.
-ENTRYPOINT ["/hollow-dcim"]
+ENTRYPOINT ["/serverservice"]
 CMD ["serve"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,9 +11,11 @@ RUN go mod download
 # Copy local code to the container image.
 COPY . ./
 
+RUN go mod tidy
+
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o hollow-dcim
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o serverservice
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine
@@ -22,7 +24,7 @@ FROM alpine:3
 RUN apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/hollow-dcim /hollow-dcim
+COPY --from=builder /app/serverservice /serverservice
 
 # Run the web service on container startup.
-CMD ["/hollow-dcim", "serve"]
+CMD ["/serverservice", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,22 @@ all: lint test
 PHONY: test coverage lint golint clean vendor local-dev-databases docker-up docker-down integration-test unit-test
 GOOS=linux
 DB_STRING=host=localhost port=26257 user=root sslmode=disable
-DEV_DB=${DB_STRING} dbname=hollow_dcim_dev
-TEST_DB=${DB_STRING} dbname=hollow_dcim_test
+DEV_DB=${DB_STRING} dbname=serverservice
+TEST_DB=${DB_STRING} dbname=serverservice_test
 
 test: | unit-test integration-test
 
-integration-test: docker-up test-database
+integration-test: test-database
 	@echo Running integration tests...
-	@HOLLOW_DCIM_TEST_DB="${TEST_DB}" go test -cover -tags testtools,integration -p 1 ./...
+	@SERVERSERVICE_DB_URI="${TEST_DB}" go test -cover -tags testtools,integration -p 1 ./...
 
 unit-test: | lint
 	@echo Running unit tests...
 	@go test -cover -short -tags testtools ./...
 
-coverage: | docker-up test-database
+coverage: | test-database
 	@echo Generating coverage report...
-	@HOLLOW_DCIM_TEST_DB="${TEST_DB}" go test ./... -race -coverprofile=coverage.out -covermode=atomic -tags testtools -p 1
+	@SERVERSERVICE_DB_URI="${TEST_DB}" go test ./... -race -coverprofile=coverage.out -covermode=atomic -tags testtools -p 1
 	@go tool cover -func=coverage.out
 	@go tool cover -html=coverage.out
 
@@ -46,13 +46,13 @@ docker-down:
 docker-clean:
 	@docker-compose down --volumes
 
-dev-database:
-	@cockroach sql --insecure -e "drop database if exists hollow_dcim_dev"
-	@cockroach sql --insecure -e "create database hollow_dcim_dev"
-	@GOOSE_DRIVER=postgres GOOSE_DBSTRING="${DEV_DB}" goose -dir=db/migrations up
+dev-database: | vendor
+	@cockroach sql --insecure -e "drop database if exists serverservice"
+	@cockroach sql --insecure -e "create database serverservice"
+	@SERVERSERVICE_DB_URI="${DEV_DB}" go run main.go migrate up
 
-test-database:
-	@cockroach sql --insecure -e "drop database if exists hollow_dcim_test"
-	@cockroach sql --insecure -e "create database hollow_dcim_test"
-	@GOOSE_DRIVER=postgres GOOSE_DBSTRING="${TEST_DB}" goose -dir=db/migrations up
-	@cockroach sql --insecure -e "use hollow_dcim_test; ALTER TABLE attributes DROP CONSTRAINT check_server_id_server_component_id; ALTER TABLE versioned_attributes DROP CONSTRAINT check_server_id_server_component_id;"
+test-database: | vendor
+	@cockroach sql --insecure -e "drop database if exists serverservice_test"
+	@cockroach sql --insecure -e "create database serverservice_test"
+	@SERVERSERVICE_DB_URI="${TEST_DB}" go run main.go migrate up
+	@cockroach sql --insecure -e "use serverservice_test; ALTER TABLE attributes DROP CONSTRAINT check_server_id_server_component_id; ALTER TABLE versioned_attributes DROP CONSTRAINT check_server_id_server_component_id;"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# Hollow
+# Server Service
 
 > This repository is [Experimental](https://github.com/packethost/standards/blob/master/experimental-statement.md) meaning that it's based on untested ideas or techniques and not yet established or finalized or involves a radically new and innovative style!
 > This means that support is best effort (at best!) and we strongly encourage you to NOT use this in production.
 
-North of Neverland, `Hollow` is the magical kingdom where fairies are born and is their home.
-
-More pragmatically, Hollow is the combination of a golang-based API built on top of cockroachdb primarily responsible for the handling of physical asset information (e.g. metadata about our physical assets)
+The server service is a microservice within the Hollow eco-system. Server service is responsible for providing a store for physical server information. Support to storing the device components that make up the server is available. You are also able to create attributes and versioned-attributes for both servers and the server components.
 
 ## Running locally
 
@@ -15,8 +13,8 @@ To run the api server locally you can bring it up with docker-compose.
 docker compose up
 ```
 
-If you have never ran hollow before then the server will fail to start the first time. After the DB service is running you need to create the dev database. Run:
+If you have never ran `serverservice` before then the server will fail to start the first time. After the DB service is running you need to create the dev database. Run:
 
 ```
-make local-dev-databases
+make dev-database
 ```

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,2 +1,2 @@
 // Package cmd provides our CLI interface for the hollow binary
-package cmd // import "go.hollow.sh/dcim/cmd"
+package cmd // import "go.hollow.sh/serverservice/cmd"

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+
+	// import the crdbpgx for automatic retries of errors for crdb that support retry
+	_ "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgx"
+	"github.com/pressly/goose/v3"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	dbm "go.hollow.sh/serverservice/db"
+)
+
+// migrateCmd represents the migrate command
+var migrateCmd = &cobra.Command{
+	Use:   "migrate <command> [args]",
+	Short: "A brief description of your command",
+	Long: `Migrate provides a wrapper around the "goose" migration tool.
+
+Commands:
+up                   Migrate the DB to the most recent version available
+up-by-one            Migrate the DB up by 1
+up-to VERSION        Migrate the DB to a specific VERSION
+down                 Roll back the version by 1
+down-to VERSION      Roll back to a specific VERSION
+redo                 Re-run the latest migration
+reset                Roll back all migrations
+status               Dump the migration status for the current DB
+version              Print the current version of the database
+create NAME [sql|go] Creates new migration file with the current timestamp
+fix                  Apply sequential ordering to migrations
+	`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		migrate(args[0], args[1:])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(migrateCmd)
+}
+
+func migrate(command string, args []string) {
+	db, err := goose.OpenDBWithDriver("postgres", viper.GetString("db.uri"))
+	if err != nil {
+		logger.Fatalw("failed to open DB", "error", err)
+	}
+
+	defer func() {
+		if err := db.Close(); err != nil {
+			logger.Fatalw("failed to close DB", "error", err)
+		}
+	}()
+
+	goose.SetBaseFS(dbm.Migrations)
+
+	if err := goose.Run(command, db, "migrations", args...); err != nil {
+		logger.Fatalw("migrate command failed", "command", command, "error", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,8 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "hollow-dcim",
-	Short: "Hollow DCIM datastore",
+	Use:   "serverservice",
+	Short: "Server Service for Hollow ecosystem",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -35,6 +35,9 @@ func init() {
 	viperBindFlag("logging.debug", rootCmd.PersistentFlags().Lookup("debug"))
 	rootCmd.PersistentFlags().Bool("pretty", false, "enable pretty (human readable) logging output")
 	viperBindFlag("logging.pretty", rootCmd.PersistentFlags().Lookup("pretty"))
+
+	rootCmd.PersistentFlags().String("db-uri", "postgresql://root@localhost:26257/serverservice?sslmode=disable", "URI for database connection")
+	viperBindFlag("db.uri", rootCmd.PersistentFlags().Lookup("db-uri"))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -53,7 +56,7 @@ func initConfig() {
 	}
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.SetEnvPrefix("hollow_dcim")
+	viper.SetEnvPrefix("serverservice")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/viper"
 	"go.hollow.sh/toolbox/ginjwt"
 
-	"go.hollow.sh/dcim/internal/dbtools"
-	"go.hollow.sh/dcim/internal/dcimserver"
+	"go.hollow.sh/serverservice/internal/dbtools"
+	"go.hollow.sh/serverservice/internal/httpsrv"
 )
 
 // serveCmd represents the serve command
@@ -26,9 +26,6 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 	serveCmd.Flags().String("listen", "0.0.0.0:8000", "address to listen on")
 	viperBindFlag("listen", serveCmd.Flags().Lookup("listen"))
-
-	serveCmd.Flags().String("db-uri", "postgresql://root@db:26257/hollow_dev?sslmode=disable", "URI for database connection")
-	viperBindFlag("db.uri", serveCmd.Flags().Lookup("db-uri"))
 
 	serveCmd.Flags().Bool("oidc", true, "use oidc auth")
 	viperBindFlag("oidc.enabled", serveCmd.Flags().Lookup("oidc"))
@@ -56,7 +53,7 @@ func serve() {
 		"address", viper.GetString("listen"),
 	)
 
-	hs := &dcimserver.Server{
+	hs := &httpsrv.Server{
 		Logger: logger.Desugar(),
 		Listen: viper.GetString("listen"),
 		Debug:  viper.GetBool("logging.debug"),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"go.hollow.sh/toolbox/version"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version and exit",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.String())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -1,0 +1,10 @@
+// Package db provides an embedded filesystem containing all the database migrations
+package db
+
+import (
+	"embed"
+)
+
+// Migrations contain an embedded filesystem with all the sql migration files
+//go:embed migrations/*.sql
+var Migrations embed.FS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     environment:
-      - HOLLOW_JWT_AUDIENCE=https://staging.hollow.platformequinix.net
+      - SERVERSERVICE_OIDC_ENABLED=false
+      - SERVERSERVICE_DB_URI="postgresql://root@db:26257/serverservice?sslmode=disable"
     ports:
       - "8000:8000"
     links:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.hollow.sh/dcim
+module go.hollow.sh/serverservice
 
 go 1.17
 
@@ -16,6 +16,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/pressly/goose/v3 v3.1.0
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/smartystreets/assertions v1.1.0 // indirect
 	github.com/spf13/cast v1.4.0 // indirect
@@ -23,6 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0
+	github.com/ugorji/go v1.1.13 // indirect
 	github.com/volatiletech/null/v8 v8.1.2
 	github.com/volatiletech/randomize v0.0.1
 	github.com/volatiletech/sqlboiler/v4 v4.6.0
@@ -35,59 +37,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
-)
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/ericlagergren/decimal v0.0.0-20181231230500-73749d4874d5 // indirect
-	github.com/fsnotify/fsnotify v1.4.7 // indirect
-	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-playground/locales v0.13.0 // indirect
-	github.com/go-playground/universal-translator v0.17.0 // indirect
-	github.com/go-playground/validator/v10 v10.4.1 // indirect
-	github.com/gofrs/uuid v3.2.0+incompatible // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/gosimple/unidecode v1.0.0 // indirect
-	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.8.0 // indirect
-	github.com/jackc/pgio v1.0.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.6 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
-	github.com/jackc/pgtype v1.6.2 // indirect
-	github.com/jackc/pgx/v4 v4.10.1 // indirect
-	github.com/json-iterator/go v1.1.11 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
-	github.com/leodido/go-urn v1.2.0 // indirect
-	github.com/magiconair/properties v1.8.1 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/pelletier/go-toml v1.2.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.26.0 // indirect
-	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/sirupsen/logrus v1.6.0 // indirect
-	github.com/spf13/afero v1.1.2 // indirect
-	github.com/spf13/jwalterweatherman v1.0.0 // indirect
-	github.com/subosito/gotenv v1.2.0 // indirect
-	github.com/ugorji/go/codec v1.1.13 // indirect
-	github.com/volatiletech/inflect v0.0.1 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
-	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/protobuf v1.26.0-rc.1 // indirect
-	gopkg.in/ini.v1 v1.51.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 replace github.com/gin-contrib/zap => github.com/thinkgos/zap v0.0.2-0.20210226022008-5b2cf0c4d297

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/ClickHouse/clickhouse-go v1.4.5/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -32,12 +33,14 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go/v2 v2.1.1 h1:3XzfSMuUT0wBe1a3o5C0eOTcArhmmFAg2Jzh/7hhKqo=
@@ -93,7 +96,9 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -226,6 +231,7 @@ github.com/jackc/puddle v1.1.3 h1:JnPg/5Q9xVJGfjsO5CPUOjnJps1JaRUm8I9FXVCFK94=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -279,7 +285,10 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.8 h1:gDp86IdQsN/xWjIEmr9MF6o9mpksUgh0fu+9ByFxzIU=
+github.com/mattn/go-sqlite3 v1.14.8/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -307,6 +316,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -314,6 +324,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/pressly/goose/v3 v3.1.0 h1:V2Ulfm2XL9GtYNmrPUNFHieimf6diwADyMObnuuR2Mc=
+github.com/pressly/goose/v3 v3.1.0/go.mod h1:tYsY0oL0yd48jg15POIZfOZiu66mqWpfDd/nJ28KWyU=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -416,6 +428,7 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zsais/go-gin-prometheus v0.1.0 h1:bkLv1XCdzqVgQ36ScgRi09MA2UC1t3tAB6nsfErsGO4=
 github.com/zsais/go-gin-prometheus v0.1.0/go.mod h1:Slirjzuz8uM8Cw0jmPNqbneoqcUtY2GGjn2bEd4NRLY=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/internal/dbtools/doc.go
+++ b/internal/dbtools/doc.go
@@ -1,3 +1,3 @@
 // Package dbtools provides tools to help with interacting with the database,
 // including all of our utilities for database integration testing
-package dbtools // import "go.hollow.sh/dcim/internal/dbtools"
+package dbtools // import "go.hollow.sh/serverservice/internal/dbtools"

--- a/internal/dbtools/fixtures.go
+++ b/internal/dbtools/fixtures.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/types"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 //nolint:revive

--- a/internal/dbtools/hooks.go
+++ b/internal/dbtools/hooks.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gosimple/slug"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // RegisterHooks adds any hooks that are configured to the models library

--- a/internal/dbtools/testtools.go
+++ b/internal/dbtools/testtools.go
@@ -12,11 +12,11 @@ import (
 	_ "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgx"
 	"github.com/stretchr/testify/require"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // TestDBURI is the URI for the test database
-var TestDBURI = os.Getenv("HOLLOW_DCIM_TEST_DB")
+var TestDBURI = os.Getenv("SERVERSERVICE_DB_URI")
 var testDB *sql.DB
 
 func testDatastore() error {

--- a/internal/dcimserver/doc.go
+++ b/internal/dcimserver/doc.go
@@ -1,2 +1,0 @@
-// Package dcimserver provides an HTTP server
-package dcimserver // import go.hollow.sh/dcim/internal/dcimserver

--- a/internal/httpsrv/doc.go
+++ b/internal/httpsrv/doc.go
@@ -1,0 +1,3 @@
+// Package httpsrv provides the HTTP server to handle all
+// requests for the serverservice.
+package httpsrv // import go.hollow.sh/serverservice/internal/httpsrv

--- a/internal/httpsrv/server.go
+++ b/internal/httpsrv/server.go
@@ -1,4 +1,4 @@
-package dcimserver
+package httpsrv
 
 import (
 	"database/sql"
@@ -12,10 +12,10 @@ import (
 	"go.hollow.sh/toolbox/ginjwt"
 	"go.uber.org/zap"
 
-	v1api "go.hollow.sh/dcim/pkg/api/v1"
+	v1api "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
-// Server implements the Hollow server
+// Server implements the HTTP Server
 type Server struct {
 	Logger     *zap.Logger
 	Listen     string

--- a/internal/httpsrv/server_test.go
+++ b/internal/httpsrv/server_test.go
@@ -1,4 +1,4 @@
-package dcimserver_test
+package httpsrv_test
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	"go.hollow.sh/toolbox/ginjwt"
 	"go.uber.org/zap"
 
-	"go.hollow.sh/dcim/internal/dbtools"
-	"go.hollow.sh/dcim/internal/dcimserver"
+	"go.hollow.sh/serverservice/internal/dbtools"
+	"go.hollow.sh/serverservice/internal/httpsrv"
 )
 
 var serverAuthConfig = ginjwt.AuthConfig{
@@ -19,7 +19,7 @@ var serverAuthConfig = ginjwt.AuthConfig{
 }
 
 func TestUnknownRoute(t *testing.T) {
-	hs := dcimserver.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -32,7 +32,7 @@ func TestUnknownRoute(t *testing.T) {
 }
 
 func TestHealthzRoute(t *testing.T) {
-	hs := dcimserver.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -45,7 +45,7 @@ func TestHealthzRoute(t *testing.T) {
 }
 
 func TestLivenessRoute(t *testing.T) {
-	hs := dcimserver.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -58,7 +58,7 @@ func TestLivenessRoute(t *testing.T) {
 }
 
 func TestReadinessRouteDown(t *testing.T) {
-	hs := dcimserver.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig}
 	s := hs.NewServer()
 	router := s.Handler
 
@@ -73,7 +73,7 @@ func TestReadinessRouteDown(t *testing.T) {
 func TestReadinessRouteUp(t *testing.T) {
 	db := dbtools.DatabaseTest(t)
 
-	hs := dcimserver.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig, DB: db}
+	hs := httpsrv.Server{Logger: zap.NewNop(), AuthConfig: serverAuthConfig, DB: db}
 	s := hs.NewServer()
 	router := s.Handler
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 //go:generate sqlboiler crdb
 
-import "go.hollow.sh/dcim/cmd"
+import "go.hollow.sh/serverservice/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/api/v1/attributes.go
+++ b/pkg/api/v1/attributes.go
@@ -12,7 +12,7 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 	"github.com/volatiletech/sqlboiler/v4/types"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // Attributes provide the ability to apply namespaced settings to an entity.

--- a/pkg/api/v1/client_test.go
+++ b/pkg/api/v1/client_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	dcim "go.hollow.sh/dcim/pkg/api/v1"
+	dcim "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestNewClient(t *testing.T) {

--- a/pkg/api/v1/mock_client_test.go
+++ b/pkg/api/v1/mock_client_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	hollow "go.hollow.sh/dcim/pkg/api/v1"
+	hollow "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 // MockHTTPRequestDoer implements the standard http.Client interface.

--- a/pkg/api/v1/pagination.go
+++ b/pkg/api/v1/pagination.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 var (

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"go.hollow.sh/toolbox/ginjwt"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // Router provides a router for the v1 API

--- a/pkg/api/v1/router_int_test.go
+++ b/pkg/api/v1/router_int_test.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 
-	"go.hollow.sh/dcim/internal/dbtools"
-	"go.hollow.sh/dcim/internal/dcimserver"
-	hollow "go.hollow.sh/dcim/pkg/api/v1"
+	"go.hollow.sh/serverservice/internal/dbtools"
+	"go.hollow.sh/serverservice/internal/httpsrv"
+	hollow "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 type integrationServer struct {
@@ -30,7 +30,7 @@ func serverTest(t *testing.T) *integrationServer {
 
 	l := zap.NewNop()
 
-	hs := dcimserver.Server{
+	hs := httpsrv.Server{
 		Logger: l,
 		DB:     db,
 		AuthConfig: ginjwt.AuthConfig{

--- a/pkg/api/v1/router_server.go
+++ b/pkg/api/v1/router_server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 	"github.com/volatiletech/sqlboiler/v4/types"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 func (r *Router) serverList(c *gin.Context) {

--- a/pkg/api/v1/router_server_attributes.go
+++ b/pkg/api/v1/router_server_attributes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 func (r *Router) serverAttributesList(c *gin.Context) {

--- a/pkg/api/v1/router_server_attributes_test.go
+++ b/pkg/api/v1/router_server_attributes_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.hollow.sh/dcim/internal/dbtools"
-	hollow "go.hollow.sh/dcim/pkg/api/v1"
+	"go.hollow.sh/serverservice/internal/dbtools"
+	hollow "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestIntegrationServerCreateAttributes(t *testing.T) {

--- a/pkg/api/v1/router_server_component_type.go
+++ b/pkg/api/v1/router_server_component_type.go
@@ -4,7 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 func (r *Router) serverComponentTypeCreate(c *gin.Context) {

--- a/pkg/api/v1/router_server_component_type_test.go
+++ b/pkg/api/v1/router_server_component_type_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.hollow.sh/dcim/internal/dbtools"
-	hollow "go.hollow.sh/dcim/pkg/api/v1"
+	"go.hollow.sh/serverservice/internal/dbtools"
+	hollow "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestIntegrationServerComponentTypeServiceCreate(t *testing.T) {

--- a/pkg/api/v1/router_server_components_test.go
+++ b/pkg/api/v1/router_server_components_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.hollow.sh/dcim/internal/dbtools"
+	"go.hollow.sh/serverservice/internal/dbtools"
 )
 
 func TestIntegrationServerListComponents(t *testing.T) {

--- a/pkg/api/v1/router_server_test.go
+++ b/pkg/api/v1/router_server_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 
-	"go.hollow.sh/dcim/internal/dbtools"
-	hollow "go.hollow.sh/dcim/pkg/api/v1"
+	"go.hollow.sh/serverservice/internal/dbtools"
+	hollow "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestIntegrationServerList(t *testing.T) {

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/volatiletech/null/v8"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // Server represents a server in a facility

--- a/pkg/api/v1/server_component.go
+++ b/pkg/api/v1/server_component.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // ServerComponent represents a component of a server. These can be things like

--- a/pkg/api/v1/server_component_type.go
+++ b/pkg/api/v1/server_component_type.go
@@ -1,7 +1,7 @@
 package dcim
 
 import (
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // ServerComponentType provides a way to group server components by the type

--- a/pkg/api/v1/server_component_type_service_test.go
+++ b/pkg/api/v1/server_component_type_service_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	hollow "go.hollow.sh/dcim/pkg/api/v1"
+	hollow "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestServerComponentTypeServiceCreate(t *testing.T) {

--- a/pkg/api/v1/server_list_params.go
+++ b/pkg/api/v1/server_list_params.go
@@ -7,7 +7,7 @@ import (
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // ServerListParams allows you to filter the results

--- a/pkg/api/v1/server_service_test.go
+++ b/pkg/api/v1/server_service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	hollow "go.hollow.sh/dcim/pkg/api/v1"
+	hollow "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestServerServiceCreate(t *testing.T) {

--- a/pkg/api/v1/versioned_attributes.go
+++ b/pkg/api/v1/versioned_attributes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/volatiletech/sqlboiler/v4/types"
 
-	"go.hollow.sh/dcim/internal/models"
+	"go.hollow.sh/serverservice/internal/models"
 )
 
 // VersionedAttributes represents a set of attributes of an entity at a given time

--- a/sqlboiler.toml
+++ b/sqlboiler.toml
@@ -3,7 +3,7 @@ pkgname = "models"
 output = "internal/models"
 
 [crdb]
-dbname = "hollow_dcim_test"
+dbname = "serverservice_test"
 host = "localhost"
 port = 26257
 user = "root"


### PR DESCRIPTION
- Rename to serverservice to respresent the fact this service only provides server information.
- No longer rely on an external goose binary; this functionality is now available via the `serverservice migrate` comamnd.
- Add a version subcommand to print out the current version.
- Our production docker container is now a scratch container base with the alpine ca-certificates imported.
- Locally `make test` no longer starts docker-compose for you. This is to aid when working on multiple services.
- Upgrade build environment to go 1.17.
- docker compose environment no longer required Bearer tokens to access by default.