### PR TITLE
feat: [BREAKING] Allow providing your own http client that handles the auth header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gin-gonic/gin v1.7.4
 	github.com/google/uuid v1.2.0
 	github.com/gosimple/slug v1.10.0
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lib/pq v1.10.3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
@@ -63,7 +64,6 @@ require (
 	github.com/jackc/pgx/v4 v4.10.1 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect

--- a/pkg/api/v1/attributes.go
+++ b/pkg/api/v1/attributes.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"encoding/json"

--- a/pkg/api/v1/client_test.go
+++ b/pkg/api/v1/client_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"context"
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	dcim "go.hollow.sh/serverservice/pkg/api/v1"
+	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
-func TestNewClient(t *testing.T) {
+func TestNewClientWithToken(t *testing.T) {
 	var testCases = []struct {
 		testName    string
 		authToken   string
@@ -43,7 +43,7 @@ func TestNewClient(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		c, err := dcim.NewClient(tt.authToken, tt.url, nil)
+		c, err := serverservice.NewClientWithToken(tt.authToken, tt.url, nil)
 
 		if tt.expectError {
 			assert.Error(t, err, tt.testName)
@@ -51,8 +51,6 @@ func TestNewClient(t *testing.T) {
 		} else {
 			assert.NoError(t, err, tt.testName)
 			assert.NotNil(t, c, tt.testName)
-			assert.NotNil(t, c.Server, tt.testName)
-			assert.NotNil(t, c.ServerComponentType, tt.testName)
 		}
 	}
 }

--- a/pkg/api/v1/doc.go
+++ b/pkg/api/v1/doc.go
@@ -1,2 +1,2 @@
-// Package dcim provides the v1 api for hollow.
-package dcim
+// Package serverservice provides the v1 api for the server service
+package serverservice

--- a/pkg/api/v1/errors.go
+++ b/pkg/api/v1/errors.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"encoding/json"

--- a/pkg/api/v1/mock_client_test.go
+++ b/pkg/api/v1/mock_client_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"bytes"
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	hollow "go.hollow.sh/serverservice/pkg/api/v1"
+	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 // MockHTTPRequestDoer implements the standard http.Client interface.
@@ -35,7 +35,7 @@ func (md *MockHTTPRequestDoer) Do(req *http.Request) (*http.Response, error) {
 }
 
 // mockClient that can be used for testing
-func mockClient(body string, status int) *hollow.Client {
+func mockClient(body string, status int) *serverservice.Client {
 	mockDoer := &MockHTTPRequestDoer{
 		Response: &http.Response{
 			StatusCode: status,
@@ -44,7 +44,7 @@ func mockClient(body string, status int) *hollow.Client {
 		Error: nil,
 	}
 
-	c, err := hollow.NewClient("mocked", "mocked", mockDoer)
+	c, err := serverservice.NewClientWithToken("mocked", "mocked", mockDoer)
 	if err != nil {
 		return nil
 	}

--- a/pkg/api/v1/pagination.go
+++ b/pkg/api/v1/pagination.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"net/url"

--- a/pkg/api/v1/requests.go
+++ b/pkg/api/v1/requests.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"bytes"
@@ -71,7 +71,7 @@ func newDeleteRequest(ctx context.Context, uri, path string) (*http.Request, err
 }
 
 func userAgentString() string {
-	return fmt.Sprintf("hollow/%s (%s)", version.Version(), version.String())
+	return fmt.Sprintf("go-hollow-client (%s)", version.String())
 }
 
 func (c *Client) do(req *http.Request, result interface{}) error {

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"database/sql"

--- a/pkg/api/v1/router_int_test.go
+++ b/pkg/api/v1/router_int_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"net/http"
@@ -47,7 +47,7 @@ func serverTest(t *testing.T) *integrationServer {
 		h: s.Handler,
 	}
 
-	c, err := hollow.NewClient("testToken", "http://test.hollow.com", ts)
+	c, err := hollow.NewClientWithToken("testToken", "http://test.hollow.com", ts)
 	require.NoError(t, err)
 
 	ts.Client = c

--- a/pkg/api/v1/router_responses.go
+++ b/pkg/api/v1/router_responses.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"database/sql"

--- a/pkg/api/v1/router_server.go
+++ b/pkg/api/v1/router_server.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"encoding/json"

--- a/pkg/api/v1/router_server_attributes.go
+++ b/pkg/api/v1/router_server_attributes.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"database/sql"

--- a/pkg/api/v1/router_server_attributes_test.go
+++ b/pkg/api/v1/router_server_attributes_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.hollow.sh/serverservice/internal/dbtools"
-	hollow "go.hollow.sh/serverservice/pkg/api/v1"
+	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestIntegrationServerCreateAttributes(t *testing.T) {
@@ -20,12 +20,12 @@ func TestIntegrationServerCreateAttributes(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		attrs := hollow.Attributes{
+		attrs := serverservice.Attributes{
 			Namespace: "integration.tests",
 			Data:      json.RawMessage([]byte(`{"setting":"enabled"}`)),
 		}
 
-		resp, err := s.Client.Server.CreateAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), attrs)
+		resp, err := s.Client.CreateAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), attrs)
 		if !expectError {
 			require.NoError(t, err)
 			assert.NotNil(t, resp.Links.Self)
@@ -43,7 +43,7 @@ func TestIntegrationServerListAttributes(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		attrs, resp, err := s.Client.Server.ListAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), nil)
+		attrs, resp, err := s.Client.ListAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), nil)
 		if !expectError {
 			require.NoError(t, err)
 			assert.NotNil(t, resp.Links.Self)
@@ -68,7 +68,7 @@ func TestIntegrationServerListAttributes(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			_, _, err := s.Client.Server.ListAttributes(context.TODO(), tt.srvUUID, nil)
+			_, _, err := s.Client.ListAttributes(context.TODO(), tt.srvUUID, nil)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errorMsg)
 		})
@@ -81,7 +81,7 @@ func TestIntegrationServerGetAttributes(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		attr, resp, err := s.Client.Server.GetAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), dbtools.FixtureNamespaceMetadata)
+		attr, resp, err := s.Client.GetAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), dbtools.FixtureNamespaceMetadata)
 		if !expectError {
 			require.NoError(t, err)
 			assert.NotNil(t, resp.Links.Self)
@@ -99,12 +99,12 @@ func TestIntegrationServerDeleteAttributes(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		_, err := s.Client.Server.DeleteAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), dbtools.FixtureNamespaceMetadata)
+		_, err := s.Client.DeleteAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), dbtools.FixtureNamespaceMetadata)
 		if !expectError {
 			require.NoError(t, err)
 
 			// ensure the attributes are gone
-			_, _, err2 := s.Client.Server.GetAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), dbtools.FixtureNamespaceMetadata)
+			_, _, err2 := s.Client.GetAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), dbtools.FixtureNamespaceMetadata)
 			require.Error(t, err2)
 			assert.Contains(t, err2.Error(), "response code: 404, message: resource not found")
 		}
@@ -119,7 +119,7 @@ func TestIntegrationServerUpdateAttributes(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		_, err := s.Client.Server.UpdateAttributes(ctx, uuid.MustParse(dbtools.FixtureDory.ID), dbtools.FixtureNamespaceMetadata, json.RawMessage([]byte(`{"setting":"enabled"}`)))
+		_, err := s.Client.UpdateAttributes(ctx, uuid.MustParse(dbtools.FixtureDory.ID), dbtools.FixtureNamespaceMetadata, json.RawMessage([]byte(`{"setting":"enabled"}`)))
 		if !expectError {
 			// assert.Nil(t, resp.Links.Self)
 			require.NoError(t, err)

--- a/pkg/api/v1/router_server_component_type.go
+++ b/pkg/api/v1/router_server_component_type.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"github.com/gin-gonic/gin"

--- a/pkg/api/v1/router_server_component_type_test.go
+++ b/pkg/api/v1/router_server_component_type_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"context"
@@ -9,18 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.hollow.sh/serverservice/internal/dbtools"
-	hollow "go.hollow.sh/serverservice/pkg/api/v1"
+	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
-func TestIntegrationServerComponentTypeServiceCreate(t *testing.T) {
+func TestIntegrationCreateServerComponentType(t *testing.T) {
 	s := serverTest(t)
 
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		hct := hollow.ServerComponentType{Name: "integration-test"}
+		hct := serverservice.ServerComponentType{Name: "integration-test"}
 
-		resp, err := s.Client.ServerComponentType.Create(ctx, hct)
+		resp, err := s.Client.CreateServerComponentType(ctx, hct)
 		if !expectError {
 			require.NoError(t, err)
 			assert.Equal(t, "integration-test", resp.Slug)
@@ -33,13 +33,13 @@ func TestIntegrationServerComponentTypeServiceCreate(t *testing.T) {
 	})
 }
 
-func TestIntegrationServerComponentTypeServiceList(t *testing.T) {
+func TestIntegrationListServerComponentTypes(t *testing.T) {
 	s := serverTest(t)
 
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		r, resp, err := s.Client.ServerComponentType.List(ctx, nil)
+		r, resp, err := s.Client.ListServerComponentTypes(ctx, nil)
 		if !expectError {
 			require.NoError(t, err)
 			assert.Len(t, r, 1)

--- a/pkg/api/v1/router_server_components.go
+++ b/pkg/api/v1/router_server_components.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"github.com/gin-gonic/gin"

--- a/pkg/api/v1/router_server_components_test.go
+++ b/pkg/api/v1/router_server_components_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"context"
@@ -17,7 +17,7 @@ func TestIntegrationServerListComponents(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		attrs, _, err := s.Client.Server.ListComponents(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), nil)
+		attrs, _, err := s.Client.ListComponents(ctx, uuid.MustParse(dbtools.FixtureNemo.ID), nil)
 		if !expectError {
 			require.NoError(t, err)
 			assert.Len(t, attrs, 2)
@@ -40,7 +40,7 @@ func TestIntegrationServerListComponents(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			_, _, err := s.Client.Server.ListComponents(context.TODO(), tt.srvUUID, nil)
+			_, _, err := s.Client.ListComponents(context.TODO(), tt.srvUUID, nil)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errorMsg)
 		})

--- a/pkg/api/v1/router_server_test.go
+++ b/pkg/api/v1/router_server_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	"github.com/volatiletech/sqlboiler/v4/boil"
 
 	"go.hollow.sh/serverservice/internal/dbtools"
-	hollow "go.hollow.sh/serverservice/pkg/api/v1"
+	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
 func TestIntegrationServerList(t *testing.T) {
@@ -22,7 +22,7 @@ func TestIntegrationServerList(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		r, resp, err := s.Client.Server.List(ctx, nil)
+		r, resp, err := s.Client.List(ctx, nil)
 		if !expectError {
 			require.NoError(t, err)
 			assert.Len(t, r, 3)
@@ -41,15 +41,15 @@ func TestIntegrationServerList(t *testing.T) {
 	// These are the same test cases used in db/server_test.go
 	var testCases = []struct {
 		testName      string
-		params        *hollow.ServerListParams
+		params        *serverservice.ServerListParams
 		expectedUUIDs []string
 		expectError   bool
 		errorMsg      string
 	}{
 		{
 			"search by age less than 7",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:     dbtools.FixtureNamespaceMetadata,
 						Keys:          []string{"age"},
@@ -63,8 +63,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by age greater than 11 and facility code",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:        dbtools.FixtureNamespaceMetadata,
 						Keys:             []string{"age"},
@@ -79,7 +79,7 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by facility",
-			&hollow.ServerListParams{
+			&serverservice.ServerListParams{
 				FacilityCode: "Ocean",
 			},
 			[]string{dbtools.FixtureDory.ID, dbtools.FixtureMarlin.ID},
@@ -88,8 +88,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by type and location from different attributes",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceOtherdata,
 						Keys:       []string{"type"},
@@ -108,8 +108,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by nested tag",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceOtherdata,
 						Keys:       []string{"nested", "tag"},
@@ -123,8 +123,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by nested number greater than 1",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:        dbtools.FixtureNamespaceOtherdata,
 						Keys:             []string{"nested", "number"},
@@ -145,7 +145,7 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"facility filter that doesn't match",
-			&hollow.ServerListParams{
+			&serverservice.ServerListParams{
 				FacilityCode: "Neverland",
 			},
 			[]string{},
@@ -154,15 +154,15 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by type from attributes and name from versioned attributes",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceOtherdata,
 						Keys:       []string{"type"},
 						EqualValue: "clown",
 					},
 				},
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceVersioned,
 						Keys:       []string{"name"},
@@ -176,15 +176,15 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by type from attributes and name from versioned attributes, using the not current value, so nothing should return",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceOtherdata,
 						Keys:       []string{"type"},
 						EqualValue: "clown",
 					},
 				},
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceVersioned,
 						Keys:       []string{"name"},
@@ -198,8 +198,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by multiple components of the server",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						Model:  "A Lucky Fin",
 						Serial: "Right",
@@ -216,8 +216,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"ensure both components have to match when searching by multiple components of the server",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						Name:   "My Lucky Fin",
 						Vendor: "Barracuda",
@@ -236,14 +236,14 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by a single component and versioned attributes of the server",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						Model:  "A Lucky Fin",
 						Serial: "Right",
 					},
 				},
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceVersioned,
 						Keys:       []string{"name"},
@@ -257,14 +257,14 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by a single component and versioned attributes of the server",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						Model:  "A Lucky Fin",
 						Serial: "Right",
 					},
 				},
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceVersioned,
 						Keys:       []string{"name"},
@@ -278,11 +278,11 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by a single component and it's versioned attributes of the server",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						Model: "Normal Fin",
-						VersionedAttributeListParams: []hollow.AttributeListParams{
+						VersionedAttributeListParams: []serverservice.AttributeListParams{
 							{
 								Namespace:  dbtools.FixtureNamespaceVersioned,
 								Keys:       []string{"something"},
@@ -298,11 +298,11 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by a component and server attributes of the server",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						Model: "Normal Fin",
-						VersionedAttributeListParams: []hollow.AttributeListParams{
+						VersionedAttributeListParams: []serverservice.AttributeListParams{
 							{
 								Namespace:  dbtools.FixtureNamespaceVersioned,
 								Keys:       []string{"something"},
@@ -311,7 +311,7 @@ func TestIntegrationServerList(t *testing.T) {
 						},
 					},
 				},
-				AttributeListParams: []hollow.AttributeListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceOtherdata,
 						Keys:       []string{"type"},
@@ -325,11 +325,11 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by a component and server versioned attributes of the server",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						Model: "A Lucky Fin",
-						VersionedAttributeListParams: []hollow.AttributeListParams{
+						VersionedAttributeListParams: []serverservice.AttributeListParams{
 							{
 								Namespace:  dbtools.FixtureNamespaceVersioned,
 								Keys:       []string{"something"},
@@ -338,7 +338,7 @@ func TestIntegrationServerList(t *testing.T) {
 						},
 					},
 				},
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace:  dbtools.FixtureNamespaceVersioned,
 						Keys:       []string{"name"},
@@ -352,8 +352,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search by a component slug",
-			&hollow.ServerListParams{
-				ComponentListParams: []hollow.ServerComponentListParams{
+			&serverservice.ServerListParams{
+				ComponentListParams: []serverservice.ServerComponentListParams{
 					{
 						ServerComponentType: dbtools.FixtureFinType.Slug,
 					},
@@ -365,8 +365,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search for devices with a versioned attributes in a namespace with key that exists",
-			&hollow.ServerListParams{
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace: dbtools.FixtureNamespaceVersioned,
 						Keys:      []string{"name"},
@@ -379,8 +379,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search for devices with a versioned attributes in a namespace with key that doesn't exists",
-			&hollow.ServerListParams{
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace: dbtools.FixtureNamespaceVersioned,
 						Keys:      []string{"doesntExist"},
@@ -393,8 +393,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search for devices that have versioned attributes in a namespace - no filters",
-			&hollow.ServerListParams{
-				VersionedAttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				VersionedAttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace: dbtools.FixtureNamespaceVersioned,
 					},
@@ -406,8 +406,8 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search for devices that have attributes in a namespace - no filters",
-			&hollow.ServerListParams{
-				AttributeListParams: []hollow.AttributeListParams{
+			&serverservice.ServerListParams{
+				AttributeListParams: []serverservice.AttributeListParams{
 					{
 						Namespace: dbtools.FixtureNamespaceMetadata,
 					},
@@ -419,14 +419,14 @@ func TestIntegrationServerList(t *testing.T) {
 		},
 		{
 			"search for server without IncludeDeleted defined",
-			&hollow.ServerListParams{},
+			&serverservice.ServerListParams{},
 			[]string{dbtools.FixtureNemo.ID, dbtools.FixtureDory.ID, dbtools.FixtureMarlin.ID},
 			false,
 			"",
 		},
 		{
 			"search for server with IncludeDeleted defined",
-			&hollow.ServerListParams{IncludeDeleted: true},
+			&serverservice.ServerListParams{IncludeDeleted: true},
 			[]string{dbtools.FixtureNemo.ID, dbtools.FixtureDory.ID, dbtools.FixtureMarlin.ID, dbtools.FixtureChuckles.ID},
 			false,
 			"",
@@ -437,7 +437,7 @@ func TestIntegrationServerList(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			r, _, err := s.Client.Server.List(context.TODO(), tt.params)
+			r, _, err := s.Client.List(context.TODO(), tt.params)
 			if tt.expectError {
 				assert.NoError(t, err)
 				return
@@ -460,8 +460,8 @@ func TestIntegrationServerListPagination(t *testing.T) {
 	s := serverTest(t)
 	s.Client.SetToken(validToken([]string{"read", "write"}))
 
-	p := &hollow.ServerListParams{PaginationParams: &hollow.PaginationParams{Limit: 2, Page: 1}}
-	r, resp, err := s.Client.Server.List(context.TODO(), p)
+	p := &serverservice.ServerListParams{PaginationParams: &serverservice.PaginationParams{Limit: 2, Page: 1}}
+	r, resp, err := s.Client.List(context.TODO(), p)
 
 	assert.NoError(t, err)
 	assert.Len(t, r, 2)
@@ -503,7 +503,7 @@ func TestIntegrationServerGetPreload(t *testing.T) {
 	s := serverTest(t)
 	s.Client.SetToken(validToken([]string{"read", "write"}))
 
-	r, _, err := s.Client.Server.Get(context.TODO(), uuid.MustParse(dbtools.FixtureNemo.ID))
+	r, _, err := s.Client.Get(context.TODO(), uuid.MustParse(dbtools.FixtureNemo.ID))
 
 	assert.NoError(t, err)
 	assert.Len(t, r.Attributes, 2)
@@ -518,7 +518,7 @@ func TestIntegrationServerGetDeleted(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		r, _, err := s.Client.Server.Get(ctx, uuid.MustParse(dbtools.FixtureChuckles.ID))
+		r, _, err := s.Client.Get(ctx, uuid.MustParse(dbtools.FixtureChuckles.ID))
 		if !expectError {
 			require.NoError(t, err)
 			assert.Equal(t, r.UUID, uuid.MustParse(dbtools.FixtureChuckles.ID), "Expected UUID %s, got %s", dbtools.FixtureChuckles.ID, r.UUID.String())
@@ -535,7 +535,7 @@ func TestIntegrationServerListPreload(t *testing.T) {
 	s.Client.SetToken(validToken([]string{"read", "write"}))
 
 	// should only return nemo
-	r, _, err := s.Client.Server.List(context.TODO(), &hollow.ServerListParams{FacilityCode: "Sydney"})
+	r, _, err := s.Client.List(context.TODO(), &serverservice.ServerListParams{FacilityCode: "Sydney"})
 
 	assert.NoError(t, err)
 	assert.Len(t, r, 1)
@@ -551,13 +551,13 @@ func TestIntegrationServerCreate(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		testServer := hollow.Server{
+		testServer := serverservice.Server{
 			UUID:         uuid.New(),
 			Name:         "test-server",
 			FacilityCode: "int",
 		}
 
-		id, resp, err := s.Client.Server.Create(ctx, testServer)
+		id, resp, err := s.Client.Create(ctx, testServer)
 		if !expectError {
 			require.NoError(t, err)
 			assert.NotNil(t, id)
@@ -571,12 +571,12 @@ func TestIntegrationServerCreate(t *testing.T) {
 
 	var testCases = []struct {
 		testName string
-		srv      *hollow.Server
+		srv      *serverservice.Server
 		errorMsg string
 	}{
 		{
 			"fails on a duplicate uuid",
-			&hollow.Server{
+			&serverservice.Server{
 				UUID:         uuid.MustParse(dbtools.FixtureNemo.ID),
 				FacilityCode: "int-test",
 			},
@@ -586,7 +586,7 @@ func TestIntegrationServerCreate(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			_, _, err := s.Client.Server.Create(context.TODO(), *tt.srv)
+			_, _, err := s.Client.Create(context.TODO(), *tt.srv)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errorMsg)
 		})
@@ -598,7 +598,7 @@ func TestIntegrationServerDelete(t *testing.T) {
 
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
-		_, err := s.Client.Server.Delete(ctx, hollow.Server{UUID: uuid.MustParse(dbtools.FixtureNemo.ID)})
+		_, err := s.Client.Delete(ctx, serverservice.Server{UUID: uuid.MustParse(dbtools.FixtureNemo.ID)})
 
 		return err
 	})
@@ -629,18 +629,18 @@ func TestIntegrationServerDelete(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
 			if tt.create {
-				_, _, err := s.Client.Server.Create(context.TODO(), hollow.Server{UUID: tt.uuid})
+				_, _, err := s.Client.Create(context.TODO(), serverservice.Server{UUID: tt.uuid})
 				assert.NoError(t, err)
 			}
 
-			_, err := s.Client.Server.Delete(context.TODO(), hollow.Server{UUID: tt.uuid})
+			_, err := s.Client.Delete(context.TODO(), serverservice.Server{UUID: tt.uuid})
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
 				assert.NoError(t, err)
 
-				server, _, err := s.Client.Server.Get(context.TODO(), tt.uuid)
+				server, _, err := s.Client.Get(context.TODO(), tt.uuid)
 
 				assert.NoError(t, err)
 				assert.NotNil(t, server)
@@ -656,7 +656,7 @@ func TestIntegrationServerUpdate(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		resp, err := s.Client.Server.Update(ctx, uuid.MustParse(dbtools.FixtureDory.ID), hollow.Server{Name: "The New Dory"})
+		resp, err := s.Client.Update(ctx, uuid.MustParse(dbtools.FixtureDory.ID), serverservice.Server{Name: "The New Dory"})
 		if !expectError {
 			require.NoError(t, err)
 			assert.NotNil(t, resp.Links.Self)
@@ -673,9 +673,9 @@ func TestIntegrationServerServiceCreateVersionedAttributes(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		va := hollow.VersionedAttributes{Namespace: "hollow.integegration.test", Data: json.RawMessage([]byte(`{"test":"integration"}`))}
+		va := serverservice.VersionedAttributes{Namespace: "hollow.integegration.test", Data: json.RawMessage([]byte(`{"test":"integration"}`))}
 
-		resp, err := s.Client.Server.CreateVersionedAttributes(ctx, uuid.New(), va)
+		resp, err := s.Client.CreateVersionedAttributes(ctx, uuid.New(), va)
 		if !expectError {
 			assert.Equal(t, va.Namespace, resp.Slug)
 		}
@@ -691,33 +691,33 @@ func TestIntegrationServerServiceCreateVersionedAttributesIncrementCounter(t *te
 	u := uuid.New()
 	ctx := context.TODO()
 
-	va := hollow.VersionedAttributes{Namespace: "hollow.integegration.test", Data: json.RawMessage([]byte(`{"test":"integration"}`))}
-	newVA := hollow.VersionedAttributes{Namespace: "hollow.integegration.test", Data: json.RawMessage([]byte(`{"test":"integration", "something":"else"}`))}
+	va := serverservice.VersionedAttributes{Namespace: "hollow.integegration.test", Data: json.RawMessage([]byte(`{"test":"integration"}`))}
+	newVA := serverservice.VersionedAttributes{Namespace: "hollow.integegration.test", Data: json.RawMessage([]byte(`{"test":"integration", "something":"else"}`))}
 
-	_, err := s.Client.Server.CreateVersionedAttributes(ctx, u, va)
+	_, err := s.Client.CreateVersionedAttributes(ctx, u, va)
 	require.NoError(t, err)
 
 	// Ensure we only have one versioned attribute now
-	r, _, err := s.Client.Server.GetVersionedAttributes(ctx, u, "hollow.integegration.test")
+	r, _, err := s.Client.GetVersionedAttributes(ctx, u, "hollow.integegration.test")
 	require.NoError(t, err)
 	assert.Len(t, r, 1)
 
 	// Create with the same data again. This should just increase the counter, not create a new one.
-	_, err = s.Client.Server.CreateVersionedAttributes(ctx, u, va)
+	_, err = s.Client.CreateVersionedAttributes(ctx, u, va)
 	require.NoError(t, err)
 
 	// Ensure we still have only one versioned attribute and that the counter increased
-	r, _, err = s.Client.Server.GetVersionedAttributes(ctx, u, "hollow.integegration.test")
+	r, _, err = s.Client.GetVersionedAttributes(ctx, u, "hollow.integegration.test")
 	require.NoError(t, err)
 	assert.Len(t, r, 1)
 	assert.Equal(t, 1, r[0].Tally)
 
 	// Create with different data and ensure a new one is created
-	_, err = s.Client.Server.CreateVersionedAttributes(ctx, u, newVA)
+	_, err = s.Client.CreateVersionedAttributes(ctx, u, newVA)
 	require.NoError(t, err)
 
 	// Ensure we still have only one versioned attribute and that the counter increased
-	r, _, err = s.Client.Server.GetVersionedAttributes(ctx, u, "hollow.integegration.test")
+	r, _, err = s.Client.GetVersionedAttributes(ctx, u, "hollow.integegration.test")
 	require.NoError(t, err)
 	assert.Len(t, r, 2)
 	assert.Equal(t, 0, r[0].Tally)
@@ -730,7 +730,7 @@ func TestIntegrationServerServiceListVersionedAttributes(t *testing.T) {
 	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
-		res, _, err := s.Client.Server.ListVersionedAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID))
+		res, _, err := s.Client.ListVersionedAttributes(ctx, uuid.MustParse(dbtools.FixtureNemo.ID))
 		if !expectError {
 			require.Len(t, res, 2)
 			assert.Equal(t, dbtools.FixtureNamespaceVersioned, res[0].Namespace)

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"time"

--- a/pkg/api/v1/server_component.go
+++ b/pkg/api/v1/server_component.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"time"

--- a/pkg/api/v1/server_component_list_params.go
+++ b/pkg/api/v1/server_component_list_params.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"fmt"

--- a/pkg/api/v1/server_component_type.go
+++ b/pkg/api/v1/server_component_type.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"go.hollow.sh/serverservice/internal/models"

--- a/pkg/api/v1/server_component_type_list_params.go
+++ b/pkg/api/v1/server_component_type_list_params.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import "net/url"
 

--- a/pkg/api/v1/server_component_type_service.go
+++ b/pkg/api/v1/server_component_type_service.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"context"
@@ -8,28 +8,17 @@ const (
 	serverComponentTypeEndpoint = "server-component-types"
 )
 
-// ServerComponentTypeService provides the ability to interact with server component types via Hollow
-type ServerComponentTypeService interface {
-	Create(context.Context, ServerComponentType) (*ServerResponse, error)
-	List(context.Context, *ServerComponentTypeListParams) ([]ServerComponentType, *ServerResponse, error)
+// CreateServerComponentType will attempt to create a server component type in Hollow
+func (c *Client) CreateServerComponentType(ctx context.Context, t ServerComponentType) (*ServerResponse, error) {
+	return c.post(ctx, serverComponentTypeEndpoint, t)
 }
 
-// ServerComponentTypeServiceClient implements ServerComponentTypeService
-type ServerComponentTypeServiceClient struct {
-	client *Client
-}
-
-// Create will attempt to create a server component type in Hollow
-func (c *ServerComponentTypeServiceClient) Create(ctx context.Context, t ServerComponentType) (*ServerResponse, error) {
-	return c.client.post(ctx, serverComponentTypeEndpoint, t)
-}
-
-// List will return the server component types with optional params
-func (c *ServerComponentTypeServiceClient) List(ctx context.Context, params *ServerComponentTypeListParams) ([]ServerComponentType, *ServerResponse, error) {
+// ListServerComponentTypes will return the server component types with optional params
+func (c *Client) ListServerComponentTypes(ctx context.Context, params *ServerComponentTypeListParams) ([]ServerComponentType, *ServerResponse, error) {
 	cts := &[]ServerComponentType{}
 	resp := ServerResponse{Records: cts}
 
-	if err := c.client.list(ctx, serverComponentTypeEndpoint, params, &resp); err != nil {
+	if err := c.list(ctx, serverComponentTypeEndpoint, params, &resp); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/api/v1/server_component_type_service_test.go
+++ b/pkg/api/v1/server_component_type_service_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"context"
@@ -17,7 +17,7 @@ func TestServerComponentTypeServiceCreate(t *testing.T) {
 		jsonResponse := json.RawMessage([]byte(`{"message": "resource created", "slug":"slug-1"}`))
 
 		c := mockClient(string(jsonResponse), respCode)
-		resp, err := c.ServerComponentType.Create(ctx, hct)
+		resp, err := c.CreateServerComponentType(ctx, hct)
 		if !expectError {
 			assert.Equal(t, "slug-1", resp.Slug)
 		}
@@ -33,7 +33,7 @@ func TestServerComponentTypeServiceList(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.ServerComponentType.List(ctx, nil)
+		res, _, err := c.ListServerComponentTypes(ctx, nil)
 		if !expectError {
 			assert.ElementsMatch(t, hct, res)
 		}

--- a/pkg/api/v1/server_list_params.go
+++ b/pkg/api/v1/server_list_params.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"fmt"

--- a/pkg/api/v1/server_service_test.go
+++ b/pkg/api/v1/server_service_test.go
@@ -1,4 +1,4 @@
-package dcim_test
+package serverservice_test
 
 import (
 	"context"
@@ -18,7 +18,7 @@ func TestServerServiceCreate(t *testing.T) {
 		jsonResponse := json.RawMessage([]byte(`{"message": "resource created", "slug":"00000000-0000-0000-0000-000000001234"}`))
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.Create(ctx, srv)
+		res, _, err := c.Create(ctx, srv)
 		if !expectError {
 			assert.Equal(t, "00000000-0000-0000-0000-000000001234", res.String())
 		}
@@ -31,7 +31,7 @@ func TestServerServiceDelete(t *testing.T) {
 	mockClientTests(t, func(ctx context.Context, respCode int, expectError bool) error {
 		jsonResponse := json.RawMessage([]byte(`{"message": "resource deleted"}`))
 		c := mockClient(string(jsonResponse), respCode)
-		_, err := c.Server.Delete(ctx, hollow.Server{UUID: uuid.New()})
+		_, err := c.Delete(ctx, hollow.Server{UUID: uuid.New()})
 
 		return err
 	})
@@ -43,7 +43,7 @@ func TestServerServiceGet(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.Get(ctx, srv.UUID)
+		res, _, err := c.Get(ctx, srv.UUID)
 		if !expectError {
 			assert.Equal(t, srv.UUID, res.UUID)
 			assert.Equal(t, srv.FacilityCode, res.FacilityCode)
@@ -60,7 +60,7 @@ func TestServerServiceList(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.List(ctx, nil)
+		res, _, err := c.List(ctx, nil)
 		if !expectError {
 			assert.ElementsMatch(t, srv, res)
 		}
@@ -75,7 +75,7 @@ func TestServerServiceUpdate(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		_, err = c.Server.Update(ctx, uuid.UUID{}, hollow.Server{Name: "new-name"})
+		_, err = c.Update(ctx, uuid.UUID{}, hollow.Server{Name: "new-name"})
 
 		return err
 	})
@@ -87,7 +87,7 @@ func TestServerServiceCreateAttributes(t *testing.T) {
 		jsonResponse := json.RawMessage([]byte(`{"message": "resource created"}`))
 
 		c := mockClient(string(jsonResponse), respCode)
-		_, err := c.Server.CreateAttributes(ctx, uuid.New(), attr)
+		_, err := c.CreateAttributes(ctx, uuid.New(), attr)
 
 		return err
 	})
@@ -99,7 +99,7 @@ func TestServerServiceGetAttributes(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.GetAttributes(ctx, uuid.UUID{}, "unit-test")
+		res, _, err := c.GetAttributes(ctx, uuid.UUID{}, "unit-test")
 		if !expectError {
 			assert.Equal(t, attr, res)
 		}
@@ -114,7 +114,7 @@ func TestServerServiceDeleteAttributes(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		_, err = c.Server.DeleteAttributes(ctx, uuid.UUID{}, "unit-test")
+		_, err = c.DeleteAttributes(ctx, uuid.UUID{}, "unit-test")
 
 		return err
 	})
@@ -127,7 +127,7 @@ func TestServerServiceListAttributes(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.ListAttributes(ctx, uuid.UUID{}, nil)
+		res, _, err := c.ListAttributes(ctx, uuid.UUID{}, nil)
 		if !expectError {
 			assert.ElementsMatch(t, attrs, res)
 		}
@@ -142,7 +142,7 @@ func TestServerServiceUpdateAttributes(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		_, err = c.Server.UpdateAttributes(ctx, uuid.UUID{}, "unit-test", json.RawMessage([]byte(`{"test":"unit"}`)))
+		_, err = c.UpdateAttributes(ctx, uuid.UUID{}, "unit-test", json.RawMessage([]byte(`{"test":"unit"}`)))
 
 		return err
 	})
@@ -155,7 +155,7 @@ func TestServerServiceListComponents(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.ListComponents(ctx, uuid.UUID{}, nil)
+		res, _, err := c.ListComponents(ctx, uuid.UUID{}, nil)
 		if !expectError {
 			assert.ElementsMatch(t, sc, res)
 		}
@@ -170,7 +170,7 @@ func TestServerServiceVersionedAttributeCreate(t *testing.T) {
 		jsonResponse := json.RawMessage([]byte(`{"message": "resource created", "slug":"the-namespace"}`))
 
 		c := mockClient(string(jsonResponse), respCode)
-		resp, err := c.Server.CreateVersionedAttributes(ctx, uuid.New(), va)
+		resp, err := c.CreateVersionedAttributes(ctx, uuid.New(), va)
 		if !expectError {
 			assert.Equal(t, "the-namespace", resp.Slug)
 		}
@@ -186,7 +186,7 @@ func TestServerServiceGetVersionedAttributess(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.GetVersionedAttributes(ctx, uuid.New(), "namespace")
+		res, _, err := c.GetVersionedAttributes(ctx, uuid.New(), "namespace")
 		if !expectError {
 			assert.ElementsMatch(t, va, res)
 		}
@@ -202,7 +202,7 @@ func TestServerServiceListVersionedAttributess(t *testing.T) {
 		require.Nil(t, err)
 
 		c := mockClient(string(jsonResponse), respCode)
-		res, _, err := c.Server.ListVersionedAttributes(ctx, uuid.New())
+		res, _, err := c.ListVersionedAttributes(ctx, uuid.New())
 		if !expectError {
 			assert.ElementsMatch(t, va, res)
 		}

--- a/pkg/api/v1/versioned_attributes.go
+++ b/pkg/api/v1/versioned_attributes.go
@@ -1,4 +1,4 @@
-package dcim
+package serverservice
 
 import (
 	"encoding/json"


### PR DESCRIPTION
This also provides some client cleanup as we continue to move forward with additional services.

This changes the `NewClient` signature. This should be the preferred client creation. Currently we control all the code bases that pull this in and will want to update most of those to use this new method so I think this is an acceptable approach.