### PR TITLE
remove deleted_at index

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,6 +9,7 @@ on:
       - go.sum
       - '**.go'
       - '**.yaml'
+      - '**.sql'
     branches:
       - main
   pull_request:
@@ -17,6 +18,7 @@ on:
       - go.sum
       - '**.go'
       - '**.yaml'
+      - '**.sql'
 
 jobs:
   golangci:

--- a/db/migrations/00008_remove_deleted_at_index.sql
+++ b/db/migrations/00008_remove_deleted_at_index.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP INDEX idx_deleted_at;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE INDEX idx_deleted_at ON servers (deleted_at) where deleted_at is null;
+-- +goose StatementEnd

--- a/internal/models/crdb_main_test.go
+++ b/internal/models/crdb_main_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/volatiletech/randomize"
 )
 
-var rgxCDBFkey = regexp.MustCompile(`(?m)((\n)?.*CONSTRAINT.*?FOREIGN KEY.*?\n|(\n)?[a-zA-Z _]*VALIDATE CONSTRAINT.*?.*?\n)`)
+// This manual edit is important, try not to merge in overrides when running `go generate`:
+// https://github.com/glerchundi/sqlboiler-crdb/pull/40
+var rgxCDBFkey = regexp.MustCompile(`(?m)((\n)?.*CONSTRAINT.*?FOREIGN KEY.*?\n|(\n)?[a-zA-Z _\.]*VALIDATE CONSTRAINT.*?.*?\n)`)
 
 type crdbTester struct {
 	dbConn *sql.DB

--- a/internal/models/crdb_main_test.go
+++ b/internal/models/crdb_main_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/volatiletech/randomize"
 )
 
-// This manual edit is important, try not to merge in overrides when running `go generate`:
-// https://github.com/glerchundi/sqlboiler-crdb/pull/40
-var rgxCDBFkey = regexp.MustCompile(`(?m)((\n)?.*CONSTRAINT.*?FOREIGN KEY.*?\n|(\n)?[a-zA-Z _\.]*VALIDATE CONSTRAINT.*?.*?\n)`)
+var rgxCDBFkey = regexp.MustCompile(`(?m)((\n)?.*CONSTRAINT.*?FOREIGN KEY.*?\n|(\n)?[a-zA-Z _]*VALIDATE CONSTRAINT.*?.*?\n)`)
 
 type crdbTester struct {
 	dbConn *sql.DB


### PR DESCRIPTION
while the addition of the `deleted_at` index migration runs fine, we see issues later when using the client:

```
serverservice-migrate_1  | 2021/09/27 15:19:10 OK    00001_init.sql
serverservice-migrate_1  | 2021/09/27 15:19:11 OK    00002_components_versioned_attrs.sql
serverservice-migrate_1  | 2021/09/27 15:19:11 OK    00003_components_versioned_attrs_indexes.sql
serverservice-migrate_1  | 2021/09/27 15:19:11 OK    00004_server_component_type_slug.sql
serverservice-migrate_1  | 2021/09/27 15:19:12 OK    00005_versioned_attributes_repeat_counter.sql
serverservice-migrate_1  | 2021/09/27 15:19:12 OK    00006_fix_non_nulls.sql
serverservice-migrate_1  | 2021/09/27 15:24:19 OK    00007_deleted_at_attr.sql
serverservice-migrate_1  | 2021/09/27 15:24:19 goose: no migrations to run. current version: 7
```

Client example:
```
example_1               | 2021-09-27T15:50:57.629Z     ERROR   example/hollow.go:172  Error getting server from hollow        {"error": "hollow client received a server error - response code: 500, message: datastore error, details: models: failed to execute a one query for servers: bind failed to execute query: pq: internal error: unexpected error during partial index predicate type resolution: column \"deleted_at\" does not exist"}
```

And cockroach itself throws a siimlar error that when connecting initially:
```
root@:26257/defaultdb> select * from servers;
ERROR: internal error: unexpected error during partial index predicate type resolution: column "deleted_at" does not exist
SQLSTATE: XX000
DETAIL: stack trace:
/go/src/github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder/partial_index.go:205: func1()
```

There are a few reasons why this index is potentially problematic, but let's migrate away from it since we won't leverage it directly and its causing issues.