### PR TITLE
set time to an interface for nil comparisons

### DIFF
--- a/pkg/api/v1/router_server_test.go
+++ b/pkg/api/v1/router_server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -559,6 +560,7 @@ func TestIntegrationServerGetPreload(t *testing.T) {
 	assert.Len(t, r.VersionedAttributes, 1)
 	assert.JSONEq(t, string(r.VersionedAttributes[0].Data), string(dbtools.FixtureNemoVersionedNew.Data))
 	assert.Len(t, r.Components, 2)
+	assert.Nil(t, r.DeletedAt, "DeletedAt should be nil for non deleted server")
 }
 
 func TestIntegrationServerGetDeleted(t *testing.T) {
@@ -572,7 +574,8 @@ func TestIntegrationServerGetDeleted(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, r.UUID, uuid.MustParse(dbtools.FixtureChuckles.ID), "Expected UUID %s, got %s", dbtools.FixtureChuckles.ID, r.UUID.String())
 			assert.Equal(t, r.Name, dbtools.FixtureChuckles.Name.String)
-			assert.NotEqual(t, r.DeletedAt, null.Time{}.Time)
+			assert.NotNil(t, r.DeletedAt, "A deleted server should not have a nil interface")
+			assert.Equal(t, dbtools.FixtureChuckles.DeletedAt.Time.Format(time.RFC3339), r.DeletedAt.(string))
 		}
 
 		return err

--- a/pkg/api/v1/server.go
+++ b/pkg/api/v1/server.go
@@ -20,7 +20,8 @@ type Server struct {
 	VersionedAttributes []VersionedAttributes `json:"versioned_attributes"`
 	CreatedAt           time.Time             `json:"created_at"`
 	UpdatedAt           time.Time             `json:"updated_at"`
-	DeletedAt           time.Time             `json:"deleted_at,omitempty"`
+	// DeletedAt is a pointer to a Time in order to be able to support checks for nil time
+	DeletedAt interface{} `json:"deleted_at,omitempty"`
 }
 
 func (r *Router) getServers(c *gin.Context, params ServerListParams) (models.ServerSlice, int64, error) {
@@ -54,7 +55,13 @@ func (s *Server) fromDBModel(dbS *models.Server) error {
 	s.FacilityCode = dbS.FacilityCode.String
 	s.CreatedAt = dbS.CreatedAt.Time
 	s.UpdatedAt = dbS.UpdatedAt.Time
-	s.DeletedAt = dbS.DeletedAt.Time
+
+	nullTime := null.Time{}.Time
+	if dbS.DeletedAt.Time == nullTime {
+		s.DeletedAt = nil
+	} else {
+		s.DeletedAt = &dbS.DeletedAt.Time
+	}
 
 	if dbS.R != nil {
 		if dbS.R.Attributes != nil {
@@ -90,6 +97,10 @@ func (s *Server) toDBModel() (*models.Server, error) {
 
 	if s.UUID.String() != uuid.Nil.String() {
 		dbS.ID = s.UUID.String()
+	}
+
+	if s.DeletedAt == nil {
+		dbS.DeletedAt = null.Time{}
 	}
 
 	return dbS, nil


### PR DESCRIPTION
Setting the `DeletedAt` object allows us to set a nil value, and thus have simple `Server.DeletedAt == nil` comparisons.

If we were to use a pointer to a `time.Time` object, something about the modeling handling sets the `time.Time` pointer to the zero value of `*time.Time`, which does not compare to nil, but instead an initialized `*time.Time` object. I can get around this by either comparing against something like `var nilTime *time.Time` or with `reflect.ValueOf(r.DeletedAt).IsNil()`, but if the goal is to simply comparisons against null TIme, I think we're better served setting the `DeletedAt` as an interface.

Alternatively, see https://github.com/metal-toolbox/hollow-serverservice/pull/42