### PR TITLE
Sign container images and generate SBOM as part of release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       -
         name: Login to GHCR
@@ -25,7 +28,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
+      -
+        name: install cosign
+        uses: sigstore/cosign-installer@main
+      -
+        uses: anchore/sbom-action/download-syft@v0.11.0
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
@@ -34,3 +42,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_EXPERIMENTAL: 1

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.test
 *.out
 /dist
+cosign.key
+.vscode/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,3 +52,39 @@ dockers:
     image_templates:
       - "ghcr.io/metal-toolbox/hollow-{{.ProjectName}}:{{ .Tag }}"
     dockerfile: Dockerfile
+    build_flag_templates:
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: all
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: all
+    output: true


### PR DESCRIPTION
This adds keyless signatures powered by cosign to our releases as part
of the goreleaser configuration. It also generates an SBOM using syft.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
