### PR TITLE
cosign: use `sign` and not `sign-blob` for image signing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,7 @@ docker_signs:
     signature: "${artifact}.sig"
     certificate: "${artifact}.pem"
     args:
-      - "sign-blob"
+      - "sign"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"


### PR DESCRIPTION
sign-blog takes a file, while we want to sign a container image.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
