### PR TITLE
Remove unneded parts from `docker_signs` section in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,13 +78,9 @@ signs:
 
 docker_signs:
   - cmd: cosign
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
     args:
       - "sign"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
       - "${artifact}"
     artifacts: all
     output: true


### PR DESCRIPTION
This was not needed and might affect builds.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
