### PR TITLE
Add custom docker-compose renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "docker-compose": {
+    "fileMatch": ["^quickstart(.*)?.ya?ml$"]
+  }
 }


### PR DESCRIPTION
This allows us to automatically get updates for container images from
our docker compose files. Even if these are only used for testing, this
is useful as it allows us to get a notion of compatibility.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
