### PR TITLE
Automatically cut releases on the 2nd of each month

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,24 @@
+name: Auto tag
+
+# Automatically push a tag at 12:15 (UTC) on day-of-month 2
+
+on:
+  schedule:
+    - cron: '15 12 2 * *'
+
+jobs:
+  auto-tag:
+    name: Automatic Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.39.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          WITH_V: true

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - v**
 
 jobs:
   goreleaser:


### PR DESCRIPTION
This utilizies a GitHub action that automatically cuts releases on the
2nd each month. Note that the release job will fail if there are no
patches to add to a release. This is non-fatal thus we just won't have a
release.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
