### PR TITLE
fixes TestIntegrationServerUpdateComponents intermittent failures

### DIFF
--- a/pkg/api/v1/router_server_components_test.go
+++ b/pkg/api/v1/router_server_components_test.go
@@ -529,9 +529,7 @@ func TestIntegrationServerUpdateComponents(t *testing.T) {
 
 	// identify component and server fixture for test
 	for _, server := range servers {
-		server := server
 		for _, c := range server.Components {
-			c := c
 			if c.Name == fixtureComponentName && c.Vendor == fixtureComponentVendor && c.Serial == fixtureComponentSerial {
 				componentFixture = append(componentFixture, c)
 				serverFixture = server


### PR DESCRIPTION
This resolves #105 where the test case made some assumptions about the fixtures and failed
intermittently.

The change fixes up the `TestIntegrationServerUpdateComponents` test case method to work with components that are present in the fixture data. The earlier revision of this test assumed the first element in the servers, components list is the expected fixture it needs to work with, which is not often the case, since servers, components can be returned in a random order and so the test would fail intermittently.