### PR TITLE
Fix scopes for server component firmwares

### DIFF
--- a/pkg/api/v1/client_test.go
+++ b/pkg/api/v1/client_test.go
@@ -110,6 +110,10 @@ func mockClientTests(t *testing.T, f func(ctx context.Context, respCode int, exp
 }
 
 func realClientTests(t *testing.T, f func(ctx context.Context, token string, respCode int, expectError bool) error) {
+	scopedRealClientTests(t, adminScopes, f)
+}
+
+func scopedRealClientTests(t *testing.T, scopes []string, f func(ctx context.Context, token string, respCode int, expectError bool) error) {
 	ctx := context.Background()
 	timeCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 
@@ -126,7 +130,7 @@ func realClientTests(t *testing.T, f func(ctx context.Context, token string, res
 		{
 			"happy path",
 			ctx,
-			validToken(adminScopes),
+			validToken(scopes),
 			http.StatusOK,
 			false,
 			"",
@@ -151,7 +155,7 @@ func realClientTests(t *testing.T, f func(ctx context.Context, token string, res
 		{
 			"fake timeout",
 			timeCtx,
-			validToken(adminScopes),
+			validToken(scopes),
 			http.StatusOK,
 			true,
 			"context deadline exceeded",

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -90,11 +90,11 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 	// /server-component-firmwares
 	srvCmpntFw := rg.Group("/server-component-firmwares")
 	{
-		srvCmpntFw.GET("", amw.RequiredScopes(readScopes("server")), r.serverComponentFirmwareList)
-		srvCmpntFw.POST("", amw.RequiredScopes(createScopes("server")), r.serverComponentFirmwareCreate)
-		srvCmpntFw.GET("/:uuid", amw.RequiredScopes(readScopes("server")), r.serverComponentFirmwareGet)
-		srvCmpntFw.PUT("/:uuid", amw.RequiredScopes(updateScopes("server")), r.serverComponentFirmwareUpdate)
-		srvCmpntFw.DELETE("/:uuid", amw.RequiredScopes(deleteScopes("server")), r.serverComponentFirmwareDelete)
+		srvCmpntFw.GET("", amw.RequiredScopes(readScopes("server-component-firmwares")), r.serverComponentFirmwareList)
+		srvCmpntFw.POST("", amw.RequiredScopes(createScopes("server-component-firmwares")), r.serverComponentFirmwareCreate)
+		srvCmpntFw.GET("/:uuid", amw.RequiredScopes(readScopes("server-component-firmwares")), r.serverComponentFirmwareGet)
+		srvCmpntFw.PUT("/:uuid", amw.RequiredScopes(updateScopes("server-component-firmwares")), r.serverComponentFirmwareUpdate)
+		srvCmpntFw.DELETE("/:uuid", amw.RequiredScopes(deleteScopes("server-component-firmwares")), r.serverComponentFirmwareDelete)
 	}
 
 	// /server-credential-types

--- a/pkg/api/v1/router_firmware_test.go
+++ b/pkg/api/v1/router_firmware_test.go
@@ -16,7 +16,8 @@ import (
 func TestIntegrationFirmwareList(t *testing.T) {
 	s := serverTest(t)
 
-	realClientTests(t, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
+	scopes := []string{"read:server-component-firmwares", "write:server-component-firmwares"}
+	scopedRealClientTests(t, scopes, func(ctx context.Context, authToken string, respCode int, expectError bool) error {
 		s.Client.SetToken(authToken)
 
 		params := serverservice.ComponentFirmwareVersionListParams{


### PR DESCRIPTION
The endpoint `/server-component-firmwares` is incorrectly requesting `server` scopes instead of `server-component-firmwares`. This PR corrects the scopes and add an additional `scopedRealClientTests` test function to help test scoped requests.