### PR TITLE
router_responses: return status 400 on duplicate key error

### DIFF
--- a/pkg/api/v1/router_firmware_test.go
+++ b/pkg/api/v1/router_firmware_test.go
@@ -219,7 +219,7 @@ func TestIntegrationServerComponentFirmwareCreate(t *testing.T) {
 				RepositoryURL: "https://example-bucket.s3.awsamazon.com/foobar",
 			},
 			true,
-			"500",
+			"400",
 			"unable to insert into component_firmware_version: pq: duplicate key value violates unique constraint \"vendor_model_version_unique\"",
 		},
 	}

--- a/pkg/api/v1/router_responses.go
+++ b/pkg/api/v1/router_responses.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -94,6 +95,10 @@ func updatedResponse(c *gin.Context, slug string) {
 }
 
 func dbErrorResponse(c *gin.Context, err error) {
+	if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+		badRequestResponse(c, "", err)
+	}
+
 	if errors.Is(err, sql.ErrNoRows) {
 		c.JSON(http.StatusNotFound, &ServerResponse{Message: "resource not found", Error: err.Error()})
 	} else {


### PR DESCRIPTION
Instead of returning all db errors as 500, return 400s so that the client can differentiate between a server error and a invalid request.

https://www.rfc-editor.org/rfc/rfc7231#section-6.5.1

This prevents clients retrying when the db error not a server side problem.