### PR TITLE
api/v1/server_list_params: fixes incorrect record count

### DIFF
--- a/pkg/api/v1/router_server_test.go
+++ b/pkg/api/v1/router_server_test.go
@@ -483,7 +483,7 @@ func TestIntegrationServerList(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
-			r, _, err := s.Client.List(context.TODO(), tt.params)
+			servers, resp, err := s.Client.List(context.TODO(), tt.params)
 			if tt.expectError {
 				assert.NoError(t, err)
 				return
@@ -491,7 +491,9 @@ func TestIntegrationServerList(t *testing.T) {
 
 			var actual []string
 
-			for _, srv := range r {
+			assert.Equal(t, int64(len(servers)), resp.TotalRecordCount)
+
+			for _, srv := range servers {
 				actual = append(actual, srv.UUID.String())
 			}
 

--- a/pkg/api/v1/server_list_params.go
+++ b/pkg/api/v1/server_list_params.go
@@ -49,7 +49,7 @@ func (p *ServerListParams) queryMods() []qm.QueryMod {
 		mods = append(mods, m)
 	}
 
-	mods = append(mods, qm.Select("distinct servers.*"))
+	mods = append(mods, qm.Distinct("servers.*"))
 
 	for i, lp := range p.AttributeListParams {
 		tableName := fmt.Sprintf("attr_%d", i)


### PR DESCRIPTION
The sqlboiler SQL query builder seems to drop 'distinct' from `count()` when defined as `qm.Select("servers.*")`, this works when using `qm.Distinct("servers.*")` instead.