### PR TITLE
Switch to json.Unmarshal instead of json.Decoder.Decode()

### DIFF
--- a/pkg/api/v1/errors.go
+++ b/pkg/api/v1/errors.go
@@ -48,7 +48,12 @@ func ensureValidServerResponse(resp *http.Response) error {
 
 		se.StatusCode = resp.StatusCode
 
-		if err := json.NewDecoder(resp.Body).Decode(&se); err != nil {
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		if err := json.Unmarshal(data, &se); err != nil {
 			se.ErrorMessage = "failed to decode response from server"
 		}
 

--- a/pkg/api/v1/errors.go
+++ b/pkg/api/v1/errors.go
@@ -4,12 +4,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 )
 
 var (
 	// ErrNoNextPage is the error returned when there is not an additional page of resources
 	ErrNoNextPage = errors.New("no next page found")
+	// ErrUUIDParse is returned when the UUID is invalid.
+	ErrUUIDParse = errors.New("UUID parse error")
 )
 
 // ClientError is returned when invalid arguments are provided to the client

--- a/pkg/api/v1/requests.go
+++ b/pkg/api/v1/requests.go
@@ -89,5 +89,10 @@ func (c *Client) do(req *http.Request, result interface{}) error {
 
 	defer resp.Body.Close()
 
-	return json.NewDecoder(resp.Body).Decode(&result)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, result)
 }

--- a/pkg/api/v1/requests_test.go
+++ b/pkg/api/v1/requests_test.go
@@ -1,0 +1,97 @@
+package serverservice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Do(t *testing.T) {
+	serveMux1 := http.NewServeMux()
+
+	serveMux1.HandleFunc(
+		"/test",
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				assert.Equal(t, "bearer dummy", r.Header.Get("Authorization"))
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"foo": "bar"}`))
+			default:
+				t.Fatal("expected GET request, got: " + r.Method)
+			}
+		},
+	)
+
+	serveMux2 := http.NewServeMux()
+
+	serveMux2.HandleFunc(
+		"/brokenjson",
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"foo": "bar"}\n{"foo": "bar"}`))
+			default:
+				t.Fatal("expected GET request, got: " + r.Method)
+			}
+		},
+	)
+
+	testcases := []struct {
+		name                  string
+		endpoint              string
+		expectedResult        interface{}
+		serveMux              *http.ServeMux
+		expectedErrorContains string
+	}{
+		{
+			"happy path",
+			"/test",
+			map[string]string{"foo": "bar"},
+			serveMux1,
+			"",
+		},
+		{
+			"broken json returns error",
+			"/brokenjson",
+			map[string]string{"foo": "bar"},
+			serveMux2,
+			"invalid character",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.serveMux)
+			client, err := NewClientWithToken("dummy", server.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req, err := http.NewRequestWithContext(context.TODO(), "GET", server.URL+tc.endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := map[string]string{}
+
+			err = client.do(req, &result)
+			if tc.expectedErrorContains != "" {
+				if err == nil {
+					t.Fatalf("expected error: '%s', got nil", tc.expectedErrorContains)
+				}
+
+				assert.Contains(t, err.Error(), tc.expectedErrorContains)
+				return
+			}
+
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -2,12 +2,12 @@ package serverservice
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"go.hollow.sh/toolbox/ginjwt"
 	"gocloud.dev/secrets"
@@ -165,13 +165,11 @@ func (r *Router) parseUUID(c *gin.Context) (uuid.UUID, error) {
 func (r *Router) loadServerFromParams(c *gin.Context) (*models.Server, error) {
 	u, err := r.parseUUID(c)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(ErrUUIDParse, err.Error())
 	}
 
 	srv, err := models.FindServer(c.Request.Context(), r.DB, u.String())
 	if err != nil {
-		dbErrorResponse(c, err)
-
 		return nil, err
 	}
 

--- a/pkg/api/v1/router_responses.go
+++ b/pkg/api/v1/router_responses.go
@@ -97,6 +97,7 @@ func updatedResponse(c *gin.Context, slug string) {
 func dbErrorResponse(c *gin.Context, err error) {
 	if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
 		badRequestResponse(c, "", err)
+		return
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/api/v1/router_server.go
+++ b/pkg/api/v1/router_server.go
@@ -2,6 +2,7 @@ package serverservice
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 
 	"github.com/gin-gonic/gin"
@@ -111,6 +112,13 @@ func (r *Router) serverCreate(c *gin.Context) {
 func (r *Router) serverDelete(c *gin.Context) {
 	dbSRV, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -125,6 +133,13 @@ func (r *Router) serverDelete(c *gin.Context) {
 func (r *Router) serverUpdate(c *gin.Context) {
 	srv, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -150,6 +165,13 @@ func (r *Router) serverUpdate(c *gin.Context) {
 func (r *Router) serverVersionedAttributesGet(c *gin.Context) {
 	srv, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -193,6 +215,13 @@ func (r *Router) serverVersionedAttributesGet(c *gin.Context) {
 func (r *Router) serverVersionedAttributesList(c *gin.Context) {
 	srv, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 

--- a/pkg/api/v1/router_server_attributes.go
+++ b/pkg/api/v1/router_server_attributes.go
@@ -2,6 +2,7 @@ package serverservice
 
 import (
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -13,6 +14,13 @@ import (
 func (r *Router) serverAttributesList(c *gin.Context) {
 	srv, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -48,6 +56,13 @@ func (r *Router) serverAttributesList(c *gin.Context) {
 func (r *Router) serverAttributesGet(c *gin.Context) {
 	srv, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -71,6 +86,13 @@ func (r *Router) serverAttributesGet(c *gin.Context) {
 func (r *Router) serverAttributesCreate(c *gin.Context) {
 	srv, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 

--- a/pkg/api/v1/router_server_components.go
+++ b/pkg/api/v1/router_server_components.go
@@ -56,6 +56,13 @@ func (r *Router) serverComponentList(c *gin.Context) {
 func (r *Router) serverComponentGet(c *gin.Context) {
 	srv, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -96,7 +103,13 @@ func (r *Router) serverComponentsCreate(c *gin.Context) {
 	// load server based on the UUID parameter
 	server, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
 		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -211,6 +224,13 @@ func (r *Router) serverComponentUpdate(c *gin.Context) {
 	// load server based on the UUID parameter
 	server, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
+		dbErrorResponse(c, err)
+
 		return
 	}
 
@@ -339,12 +359,19 @@ func (r *Router) serverComponentDelete(c *gin.Context) {
 	// load server based on the UUID parameter
 	server, err := r.loadServerFromParams(c)
 	if err != nil {
+		if errors.Is(err, ErrUUIDParse) {
+			badRequestResponse(c, "", err)
+			return
+		}
+
 		dbErrorResponse(c, err)
+
 		return
 	}
 
 	if _, err := server.ServerComponents().DeleteAll(c.Request.Context(), r.DB); err != nil {
 		dbErrorResponse(c, err)
+
 		return
 	}
 


### PR DESCRIPTION
This is replaced for a few reasons,

 - The JSON stream decoder blocks forever if the server stops sending data
   midway in the body, see goroutine dump below [0].

 - Switching this to the json.Marshal surfaced issues in implementations where
   multiple JSON blocks were being returned in the response to the client,
    e.g: `{"foo": "bar"}{"foo": "baz"}`
   they are not caught in tests because json.Decoder.Decode doesn't have a problem with those.

 - As of now this service does not stream JSON and if the need arises,
   the implementation could be switched back to the json.Decoder along
   with a for, select loop on the request context.

[0]. Goroutine hung on json.(*Decoder).Decode
```
1 @ 0x43b196 0x44abf2 0x6bf129 0x6be71e 0x46ba21
   0x6bf128    net/http.(*http2clientStream).writeRequest+0x9c8
   /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/h2_bundle.go:8037
   0x6be71d    net/http.(*http2clientStream).doRequest+0x1d
   /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/h2_bundle.go:7899

1 @ 0x43b196 0x467afd 0x467add 0x48024c 0x6a9aab 0x6c5be5 0x56ee5f 0x56ea5b
0x56e798 0xb627dc 0xb60de7 0xb64065 0xcd3f85 0xcd30dc 0xcd2ba5 0xd128fe
0x46ba21
   0x467adc    sync.runtime_notifyListWait+0x11c
   /opt/hostedtoolcache/go/1.18.5/x64/src/runtime/sema.go:513
   0x48024b    sync.(*Cond).Wait+0x8b
   /opt/hostedtoolcache/go/1.18.5/x64/src/sync/cond.go:56
   0x6a9aaa    net/http.(*http2pipe).Read+0xea
   /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/h2_bundle.go:3663
   0x6c5be4    net/http.http2transportResponseBody.Read+0x84
   /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/h2_bundle.go:9098
   0x56ee5e    encoding/json.(*Decoder).refill+0x17e
   /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/stream.go:165
   0x56ea5a    encoding/json.(*Decoder).readValue+0xba
   /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/stream.go:140
   0x56e797    encoding/json.(*Decoder).Decode+0x77
   /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/stream.go:63
```
