### PR TITLE
Components attributes update

### DIFF
--- a/internal/dbtools/fixtures.go
+++ b/internal/dbtools/fixtures.go
@@ -27,16 +27,17 @@ var (
 	// Server Component Types
 	FixtureFinType *models.ServerComponentType
 
-	FixtureNemo                 *models.Server
-	FixtureNemoMetadata         *models.Attribute
-	FixtureNemoOtherdata        *models.Attribute
-	FixtureNemoLeftFin          *models.ServerComponent
-	FixtureNemoRightFin         *models.ServerComponent
-	FixtureNemoLeftFinVersioned *models.VersionedAttribute
-	FixtureNemoVersionedNew     *models.VersionedAttribute
-	FixtureNemoVersionedOld     *models.VersionedAttribute
-	FixtureNemoVersionedV2      *models.VersionedAttribute
-	FixtureNemoBMCSecret        *models.ServerCredential
+	FixtureNemo                  *models.Server
+	FixtureNemoMetadata          *models.Attribute
+	FixtureNemoOtherdata         *models.Attribute
+	FixtureNemoLeftFin           *models.ServerComponent
+	FixtureNemoRightFin          *models.ServerComponent
+	FixtureNemoLeftFinVersioned  *models.VersionedAttribute
+	FixtureNemoVersionedNew      *models.VersionedAttribute
+	FixtureNemoVersionedOld      *models.VersionedAttribute
+	FixtureNemoVersionedV2       *models.VersionedAttribute
+	FixtureNemoBMCSecret         *models.ServerCredential
+	FixtureNemoRightFinOtherData *models.Attribute
 
 	FixtureDory          *models.Server
 	FixtureDoryMetadata  *models.Attribute
@@ -201,6 +202,15 @@ func setupNemo(ctx context.Context, db *sqlx.DB, t *testing.T) error {
 	}
 
 	if err := FixtureNemo.AddServerComponents(ctx, db, true, FixtureNemoLeftFin, FixtureNemoRightFin); err != nil {
+		return err
+	}
+
+	FixtureNemoRightFinOtherData = &models.Attribute{
+		Namespace: FixtureNamespaceOtherdata,
+		Data:      types.JSON([]byte(`{"twitchy": true}`)),
+	}
+
+	if err := FixtureNemoRightFin.AddAttributes(ctx, db, true, FixtureNemoRightFinOtherData); err != nil {
 		return err
 	}
 

--- a/pkg/api/v1/router_server_components_test.go
+++ b/pkg/api/v1/router_server_components_test.go
@@ -636,7 +636,7 @@ func TestIntegrationServerUpdateComponents(t *testing.T) {
 			"component update on attributes",
 			serverFixture.UUID,
 			componentFixtureCopy(),
-			change{attributes: []byte(`{"status":"OK"}`)},
+			change{attributes: []byte(`{"twitches":"false"}`)},
 			"",
 			"",
 		},
@@ -689,7 +689,7 @@ func TestIntegrationServerUpdateComponents(t *testing.T) {
 			if len(tt.change.attributes) > 0 {
 				tt.components[0].Attributes = []serverservice.Attributes{
 					{
-						Namespace: "hollow.attributes",
+						Namespace: dbtools.FixtureNamespaceOtherdata,
 						Data:      tt.change.attributes,
 					},
 				}


### PR DESCRIPTION
This fixes the case where the component attribute was being added instead
of being updated, which mean't the client received a duplicate key error
for attempting a PUT request to update the component attributes.