### PR TITLE
Setup devcontainer environment

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,0 +1,20 @@
+# postgresql client config
+PGHOST=crdb
+PGPORT=26257
+PGSSLMODE=disable
+PGDATABASE=serverservice_test
+PGUSER=root
+PAGER="less -iMx4 -FXe"
+
+
+# cockroachdb container config
+COCKROACH_INSECURE=true
+COCKROACH_HOST=crdb:26257
+COCKROACH_URL="postgresql://root@crdb:26257/${PGDATABASE}?sslmode=disable"
+
+# serverservice config
+SERVERSERVICE_CRDB_URI="postgresql://root@crdb:26257/${PGDATABASE}?sslmode=disable"
+
+NATS_URL="nats://nats:4222"
+NATS_CREDS="/tmp/user.creds"
+

--- a/.devcontainer/.env.go
+++ b/.devcontainer/.env.go
@@ -1,0 +1,6 @@
+# Go config
+GOBIN=/workspace/.go/bin
+GOENV=/workspace/.devcontainer/.env.go
+GOMODCACHE=/workspace/.go/pkg/mod
+GOPATH=/workspace/.go
+GOCACHE=/workspace/.go/cache/go-build

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,46 @@
+# Used to install CRDB into the devcontainer
+FROM cockroachdb/cockroach:latest-v22.2 as CRDB
+
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.19-buster
+
+ENV NATS_CLI_VERSION=0.0.35
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        bash-completion \
+        uuid-runtime \
+        postgresql-client \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+    && pip3 install semgrep
+
+
+# Set up crdb
+RUN mkdir /usr/local/lib/cockroach
+COPY --from=CRDB /cockroach/cockroach /usr/local/bin
+COPY --from=CRDB /usr/local/lib/cockroach/libgeos.so /usr/local/lib/cockroach/
+COPY --from=CRDB /usr/local/lib/cockroach/libgeos_c.so /usr/local/lib/cockroach/
+
+# Install NATS Tooling
+RUN curl -o /tmp/install.sh  https://raw.githubusercontent.com/nats-io/nsc/main/install.sh \
+     && chmod +x /tmp/install.sh \
+     && su vscode -c "/tmp/install.sh -s /usr/local/bin" \
+     && rm -f /tmp/install.sh
+
+# [Optional] Uncomment the next lines to use go get to install anything else you need
+USER vscode
+RUN go install github.com/volatiletech/sqlboiler/v4@latest \
+    && go install github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-psql@latest \
+    && go install github.com/glerchundi/sqlboiler-crdb/v4@latest \
+    && go install github.com/nats-io/natscli/nats@v${NATS_CLI_VERSION} \
+    && go install github.com/nats-io/nkeys/nk@latest
+
+RUN mkdir /home/vscode/.ssh && \
+    chown vscode:vscode /home/vscode/.ssh && \
+    chmod 0700 /home/vscode/.ssh
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,81 @@
+// Config reference, https://containers.dev/implementors/json_reference/
+{
+	"name": "hollow-serverservice",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	"shutdownAction": "stopCompose",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"editor.tabCompletion": "on",
+				"workbench.sideBar.location": "left",
+				"workbench.colorTheme": "Dark Atom Dark",
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go",
+				"files.trimTrailingWhitespace": true,
+				"files.autoSave": "afterDelay",
+				"editor.fontFamily": "Source Code Pro",
+				"files.autoSaveDelay": 10000,
+				"terminal.external.linuxExec": "terminator",
+				"terminal.integrated.fontSize": 16,
+				"editor.fontSize": 14,
+				"go.lintTool": "golangci-lint",
+				"go.formatTool": "goimports",
+				"go.lintFlags": [
+					"--config=${workspaceFolder}/.golangci.yml",
+					"--fast"
+				],
+				"editor.formatOnSaveTimeout": 5000,
+				"editor.codeActionsOnSaveTimeout": 10000,
+				"editor.formatOnSave": true,
+				"go.vetOnSave": "package",
+				"go.vetFlags": [
+					"-all",
+					"-mod=vendor"
+				],
+				"go.testFlags": [
+					"-v"
+				],
+				"semgrep.metrics": "off",
+				"semgrep.scan.configuration": [
+					"p/trailofbits",
+					"p/golang",
+					"https://semgrep.dev/r/dgryski.semgrep-go",
+					"p/r2c-security-audit",
+					"p/insecure-transport"
+				],
+				"go.autocompleteUnimportedPackages": true,
+				"editor.codeActionsOnSave": {
+					"source.organizeImports": true
+				},
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"golang.go",
+				"vscodevim.vim",
+				"ahmadawais.shades-of-purple",
+				"semgrep.semgrep"
+			]
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/scripts/nats_account.sh",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"remoteEnv": {
+		"PATH": "${containerEnv:PATH}:/home/vscode/.nsccli/bin",
+		"NKEYS_PATH": "/nsc/nkeys",
+		"NSC_HOME": "/nsc/.config/nats/nsc"
+	},
+	"features": {
+		"git": "latest",
+		"ghcr.io/devcontainers/features/sshd:1": {}
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,90 @@
+version: "3.9"
+
+networks:
+  hollow:
+
+volumes:
+  crdb:
+    null
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VARIANT: 1.19-bullseye
+        NODE_VERSION: "none"
+    command: sleep infinity
+    env_file:
+      - .env
+      - .env.go
+    depends_on:
+      - crdb
+      - nats
+    volumes:
+      - ./nsc:/nsc
+      - ..:/workspace
+      - ~/.ssh/authorized_keys:/home/vscode/.ssh/authorized_keys:ro
+    networks:
+      - hollow
+    # Port forwarded for local development with emacs tramp
+    ports:
+      - "127.0.0.1:2222:2222"
+    # Use "forwardPorts" in **devcontainer.json** to forward a port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  # Environment setup
+  create_databases:
+    image: cockroachdb/cockroach:latest-v22.2
+    restart: on-failure:5
+    command: "sql --insecure -e 'CREATE DATABASE IF NOT EXISTS serverservice_test;'"
+    env_file:
+      - .env
+    depends_on:
+      - crdb
+    networks:
+      - hollow
+
+  # Required services (databases, etc)
+  crdb:
+    image: cockroachdb/cockroach:latest-v22.2
+    command: start-single-node --insecure
+    restart: unless-stopped
+    volumes:
+      - crdb:/cockroach/cockroach-data
+    env_file:
+      - .env
+    healthcheck:
+      test: "curl --fail http://localhost:8080/health?ready=1 || exit 1"
+      interval: "2s"
+      retries: 3
+      start_period: "15s"
+      timeout: "5s"
+    networks:
+      - hollow
+
+  nats-init:
+     image: natsio/nats-box
+     volumes:
+       - ./nsc:/nsc
+       - ./nats:/nats
+       - ./scripts:/scripts
+     command:
+       - "/scripts/nats_init.sh"
+
+  nats:
+    image: 'nats:alpine'
+    depends_on:
+      - nats-init
+    command:
+      - -c
+      - '/etc/nats/nats-server.conf'
+      - -D
+    volumes:
+      - ./nats/:/etc/nats
+    ports:
+      - "4222:4222"
+    restart: unless-stopped
+    networks:
+      - hollow

--- a/.devcontainer/nats/nats-server.conf
+++ b/.devcontainer/nats/nats-server.conf
@@ -1,0 +1,32 @@
+server_name: nats
+
+ # Client port of 4222 on all interfaces
+ port: 4222
+
+ # HTTP monitoring port
+ monitor_port: 8222
+
+ # # This is for clustering multiple servers together.
+ # cluster {
+ #   name: "cluster1"
+ #   listen: 0.0.0.0:6222
+ #   routes = [nats://127.0.0.1:6222]
+ #   cluster_advertise: nats-server:6222
+ #   connect_retries: 0
+ # }
+
+ jetstream: enabled
+ jetstream {
+   store_dir: /data/jetstream
+   max_mem: 10M
+   max_file: 1G
+ }
+
+ debug: true
+ logtime: true
+
+ max_payload: 4MB
+ lame_duck_grace_period: 10s
+ lame_duck_duration: 30s
+
+ include "resolver.conf"

--- a/.devcontainer/nsc/.config/nats/nsc/nsc.json
+++ b/.devcontainer/nsc/.config/nats/nsc/nsc.json
@@ -1,0 +1,1 @@
+{"store_root":"/home/vscode/.local/share/nats/nsc/stores","operator":"","account":"","github_updates":"nats-io/nsc","last_update":1675703087}

--- a/.devcontainer/scripts/nats_account.sh
+++ b/.devcontainer/scripts/nats_account.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+ # script to dump creds for use in our app
+
+sudo chown -R vscode /nsc
+
+ echo "Dumping NATS user creds file"
+ nsc generate creds -a serverservice -n USER > /tmp/user.creds
+
+ echo "Dumping NATS sys creds file"
+ nsc generate creds -a SYS -n sys > /tmp/sys.creds

--- a/.devcontainer/scripts/nats_init.sh
+++ b/.devcontainer/scripts/nats_init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+ # script to bootstrap a nats operator environment
+
+set +x
+
+ echo "Creating NATS operator"
+ nsc add operator --generate-signing-key --sys --name LOCAL
+ nsc edit operator -u 'nats://nats:4222'
+ nsc list operators
+ nsc describe operator
+
+ export OPERATOR_SIGNING_KEY_ID=`nsc describe operator -J | jq -r '.nats.signing_keys | first'`
+
+ echo "Creating NATS account for serverservice"
+ nsc add account -n serverservice -K ${OPERATOR_SIGNING_KEY_ID}
+ nsc edit account serverservice --sk generate --js-mem-storage -1 --js-disk-storage -1 --js-streams -1 --js-consumer -1
+ nsc describe account serverservice
+
+ export ACCOUNTS_SIGNING_KEY_ID=`nsc describe account serverservice -J | jq -r '.nats.signing_keys | first'`
+
+ echo "Creating NATS user for serverservice"
+ nsc add user -n USER -K ${ACCOUNTS_SIGNING_KEY_ID}
+ nsc describe user USER
+
+ echo "Generating NATS resolver.conf"
+ nsc generate config --mem-resolver --sys-account SYS --config-file /nats/resolver.conf --force

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@
 /dist
 cosign.key
 .vscode/
-.devcontainer/
 cockroach-data/
 coverage.txt


### PR DESCRIPTION
Shamelessly copied from https://github.com/infratographer/load-balancer-api/tree/main/.devcontainer
with a few changes to the vscode environment.

As of now the NATs container setup fails, because the devcontainer `postCreateCommand` errors out with,
```
[555175 ms] Start: Run in container: /bin/sh -c .devcontainer/scripts/nats_account.sh
Dumping NATS user creds file
Error: stat /home/vscode/.local/share/nats/nsc/stores: no such file or directory
Dumping NATS sys creds file
Error: stat /home/vscode/.local/share/nats/nsc/stores: no such file or directory
[559632 ms] postCreateCommand failed with exit code 1. Skipping any further user-provided commands.
```

@