### PR TITLE
Add params to ComponentFirmwareVersionListParams

### DIFF
--- a/pkg/api/v1/firmware_list_params.go
+++ b/pkg/api/v1/firmware_list_params.go
@@ -11,9 +11,11 @@ import (
 
 // ComponentFirmwareVersionListParams allows you to filter the results
 type ComponentFirmwareVersionListParams struct {
-	Vendor  string   `form:"vendor"`
-	Model   []string `form:"model"`
-	Version string   `form:"version"`
+	Vendor   string   `form:"vendor"`
+	Model    []string `form:"model"`
+	Version  string   `form:"version"`
+	Filename string   `form:"filename"`
+	Checksum string   `form:"checksum"`
 }
 
 func (p *ComponentFirmwareVersionListParams) setQuery(q url.Values) {
@@ -34,6 +36,14 @@ func (p *ComponentFirmwareVersionListParams) setQuery(q url.Values) {
 	if p.Version != "" {
 		q.Set("version", p.Version)
 	}
+
+	if p.Filename != "" {
+		q.Set("filename", p.Filename)
+	}
+
+	if p.Checksum != "" {
+		q.Set("checksum", p.Checksum)
+	}
 }
 
 // queryMods converts the list params into sql conditions that can be added to sql queries
@@ -52,6 +62,16 @@ func (p *ComponentFirmwareVersionListParams) queryMods() []qm.QueryMod {
 
 	if p.Version != "" {
 		m := models.ComponentFirmwareVersionWhere.Version.EQ(p.Version)
+		mods = append(mods, m)
+	}
+
+	if p.Filename != "" {
+		m := models.ComponentFirmwareVersionWhere.Filename.EQ(p.Filename)
+		mods = append(mods, m)
+	}
+
+	if p.Checksum != "" {
+		m := models.ComponentFirmwareVersionWhere.Checksum.EQ(p.Checksum)
 		mods = append(mods, m)
 	}
 

--- a/pkg/api/v1/router_firmware_test.go
+++ b/pkg/api/v1/router_firmware_test.go
@@ -80,6 +80,24 @@ func TestIntegrationFirmwareList(t *testing.T) {
 			false,
 			"",
 		},
+		{
+			"search by filename",
+			&serverservice.ComponentFirmwareVersionListParams{
+				Filename: "BIOS_C4FT0_WN64_2.6.6.EXE",
+			},
+			[]string{dbtools.FixtureDellR6515BIOS.ID},
+			false,
+			"",
+		},
+		{
+			"search by checksum",
+			&serverservice.ComponentFirmwareVersionListParams{
+				Checksum: "1ddcb3c3d0fc5925ef03a3dde768e9e245c579039dd958fc0f3a9c6368b6c5f4",
+			},
+			[]string{dbtools.FixtureDellR6515BIOS.ID},
+			false,
+			"",
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
Allows requests to `/server-component-firmwares` to filter on the filename and checksum