### PR TITLE
Change firmware uniqueness constraint

### DIFF
--- a/db/migrations/00019_firmware_update_constraint.sql
+++ b/db/migrations/00019_firmware_update_constraint.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Not possible to drop unique constraint with ALTER TABLE
+-- See https://github.com/cockroachdb/cockroach/issues/42840
+DROP INDEX vendor_component_version_unique CASCADE;
+ALTER TABLE component_firmware_version ADD CONSTRAINT vendor_component_version_filename_unique UNIQUE (vendor, component, version, filename);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP INDEX vendor_component_version_filename_unique CASCADE;
+ALTER TABLE component_firmware_version ADD CONSTRAINT vendor_component_version_unique UNIQUE (vendor, component, version);
+
+-- +goose StatementEnd

--- a/pkg/api/v1/router_firmware_test.go
+++ b/pkg/api/v1/router_firmware_test.go
@@ -206,12 +206,12 @@ func TestIntegrationServerComponentFirmwareCreate(t *testing.T) {
 			"",
 		},
 		{
-			"duplicate vendor/component/version not allowed",
+			"duplicate vendor/component/version/filename not allowed",
 			&serverservice.ComponentFirmwareVersion{
 				UUID:          uuid.New(),
 				Vendor:        "dell",
 				Model:         []string{"r615"},
-				Filename:      "foobar",
+				Filename:      "fooBAR",
 				Version:       "12345",
 				Component:     "bios",
 				Checksum:      "foobar",
@@ -220,7 +220,7 @@ func TestIntegrationServerComponentFirmwareCreate(t *testing.T) {
 			},
 			true,
 			"400",
-			"unable to insert into component_firmware_version: pq: duplicate key value violates unique constraint \"vendor_component_version_unique\"",
+			"unable to insert into component_firmware_version: pq: duplicate key value violates unique constraint \"vendor_component_version_filename_unique\"",
 		},
 	}
 


### PR DESCRIPTION
This changes the firmware uniqueness constraint to include the filename instead of only vendor/component/version as we have cases of vendors distributing firmware for the same component but different models with the same version.
