### PR TITLE
Update goreleaser deprecated options

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,7 +40,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,14 +23,15 @@ archives:
   -
     id: go
     format: tar.gz
-    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
-    replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
+    name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}64bit
+      {{- else if eq .Arch "386" }}32bit
+      {{- else if eq .Arch "arm" }}ARM
+      {{- else if eq .Arch "arm64" }}ARM64
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - README.md
 


### PR DESCRIPTION
goreleaser workflow failed due to deprecated options:
https://github.com/metal-toolbox/hollow-serverservice/actions/runs/5413798979/jobs/9839916270#step:7:18 and https://github.com/metal-toolbox/hollow-serverservice/actions/runs/5413798979/jobs/9839916270#step:7:22

- `--rm-dist` was replaced to `--clean`
- archives.replacements removed on 2023-06-06 (https://goreleaser.com/deprecations/#archivesreplacements)