### PR TITLE
Also update username when credentials are updated

### DIFF
--- a/pkg/api/v1/router_server_secrets.go
+++ b/pkg/api/v1/router_server_secrets.go
@@ -133,7 +133,10 @@ func (r *Router) serverCredentialUpsert(c *gin.Context) {
 		// search for records by server id and type id to see if we need to update or insert
 		[]string{models.ServerCredentialColumns.ServerID, models.ServerCredentialColumns.ServerCredentialTypeID},
 		// For updates only set the new value and updated at
-		boil.Whitelist(models.ServerCredentialColumns.Password, models.ServerCredentialColumns.UpdatedAt),
+		boil.Whitelist(
+			models.ServerCredentialColumns.Username,
+			models.ServerCredentialColumns.Password,
+			models.ServerCredentialColumns.UpdatedAt),
 		// For inserts set server id, type id and value
 		boil.Whitelist(
 			models.ServerCredentialColumns.ServerID,

--- a/pkg/api/v1/router_server_secrets_test.go
+++ b/pkg/api/v1/router_server_secrets_test.go
@@ -67,13 +67,14 @@ func TestIntegrationServerCredentialsUpsert(t *testing.T) {
 		assert.NotEqual(t, "mynewSecret!", secret.Password)
 
 		// Update the secret
-		_, err = s.Client.SetCredential(ctx, uuid, slug, "postgre", "mynewSecret!")
+		_, err = s.Client.SetCredential(ctx, uuid, slug, "foobar", "mynewSecret!")
 		assert.NoError(t, err)
 
 		// Get the new secret
 		newSecret, _, err := s.Client.GetCredential(ctx, uuid, slug)
 		assert.NoError(t, err)
 		assert.Equal(t, "mynewSecret!", newSecret.Password)
+		assert.Equal(t, "foobar", newSecret.Username)
 		// ensure timestamps were updated correctly
 		assert.Equal(t, secret.CreatedAt, newSecret.CreatedAt)
 		assert.NotEqual(t, newSecret.UpdatedAt, secret.UpdatedAt)


### PR DESCRIPTION
During an upsert of server credentials, if the username changed, it needs to be updated as well.