### PR TITLE
Attribute operators

### DIFF
--- a/pkg/api/v1/attribute_list_params.go
+++ b/pkg/api/v1/attribute_list_params.go
@@ -142,12 +142,15 @@ func (p *AttributeListParams) queryMods(tblName string) qm.QueryMod {
 
 	where, values := p.setJSONBWhereClause(tblName, jsonPath, values)
 
+	// namespace AND JSONB query as a query mod
 	queryMods := []qm.QueryMod{nsMod, qm.And(where, values...)}
 
+	// OR ( namespace AND JSONB query )
 	if p.AttributeOperator == AttributeLogicalOR {
 		return qm.Or2(qm.Expr(queryMods...))
 	}
 
+	// AND ( namespace AND JSONB query )
 	return qm.Expr(queryMods...)
 }
 

--- a/pkg/api/v1/attribute_list_params_test.go
+++ b/pkg/api/v1/attribute_list_params_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_encodeAttributesListParams(t *testing.T) {
+func TestEncodeAttributesListParams(t *testing.T) {
 	testCases := []struct {
 		alp         []AttributeListParams
 		key         string
@@ -32,7 +32,7 @@ func Test_encodeAttributesListParams(t *testing.T) {
 					"hollow.versioned",
 				},
 			},
-			"query with",
+			"query with namespace",
 		},
 		{
 			[]AttributeListParams{
@@ -68,6 +68,25 @@ func Test_encodeAttributesListParams(t *testing.T) {
 			},
 			"query with namespace, keys and operator, value",
 		},
+		{
+			[]AttributeListParams{
+				{
+					Namespace:         "hollow.versioned",
+					Keys:              []string{"a", "b"},
+					Operator:          "lt",
+					Value:             "5",
+					AttributeOperator: AttributeLogicalOR,
+				},
+			},
+			"key",
+			make(url.Values),
+			url.Values{
+				"key": []string{
+					"hollow.versioned~a.b~lt~5~or",
+				},
+			},
+			"query with namespace, keys and operator, value, OR Attribute Operator",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -78,7 +97,7 @@ func Test_encodeAttributesListParams(t *testing.T) {
 	}
 }
 
-func Test_parseQueryAttributesListParams(t *testing.T) {
+func TestParseQueryAttributesListParams(t *testing.T) {
 	testCases := []struct {
 		key      string
 		query    string
@@ -117,6 +136,57 @@ func Test_parseQueryAttributesListParams(t *testing.T) {
 				},
 			},
 			"query with namespace, attribute list params and 'like' operator",
+		},
+		{
+			"attr",
+			"attr=hollow.versioned~a.name~like~nemo&attr=hollow.versioned~a.name~like~bluefin~or",
+			[]AttributeListParams{
+				{
+					Namespace: "hollow.versioned",
+					Keys: []string{
+						"a",
+						"name",
+					},
+					Operator: "like",
+					Value:    "nemo%",
+				},
+				{
+					Namespace: "hollow.versioned",
+					Keys: []string{
+						"a",
+						"name",
+					},
+					Operator:          "like",
+					Value:             "bluefin%",
+					AttributeOperator: AttributeLogicalOR,
+				},
+			},
+			"query with Attribute Operator - OR",
+		},
+		{
+			"attr",
+			"attr=hollow.versioned~a.name~like~nemo&attr=hollow.versioned~a.name~like~bluefin~wtfbbq",
+			[]AttributeListParams{
+				{
+					Namespace: "hollow.versioned",
+					Keys: []string{
+						"a",
+						"name",
+					},
+					Operator: "like",
+					Value:    "nemo%",
+				},
+				{
+					Namespace: "hollow.versioned",
+					Keys: []string{
+						"a",
+						"name",
+					},
+					Operator: "like",
+					Value:    "bluefin%",
+				},
+			},
+			"query with invalid attribute operator defaults to Attribute operator - AND",
 		},
 	}
 

--- a/pkg/api/v1/firmware_set_list_params.go
+++ b/pkg/api/v1/firmware_set_list_params.go
@@ -44,7 +44,6 @@ func (p *ComponentFirmwareSetListParams) queryMods(tableName string) []qm.QueryM
 			attrJoinAsTableName := fmt.Sprintf("%s_attr_%d", tableName, i)
 			whereStmt := fmt.Sprintf("%s as %s on %s.firmware_set_id = %s.id", models.TableNames.AttributesFirmwareSet, attrJoinAsTableName, attrJoinAsTableName, tableName)
 			mods = append(mods, qm.LeftOuterJoin(whereStmt))
-
 			mods = append(mods, lp.queryMods(attrJoinAsTableName))
 		}
 	}

--- a/pkg/api/v1/router_firmware_test.go
+++ b/pkg/api/v1/router_firmware_test.go
@@ -67,7 +67,7 @@ func TestIntegrationFirmwareList(t *testing.T) {
 			&serverservice.ComponentFirmwareVersionListParams{
 				Model: []string{"X11DPH-T"},
 			},
-			[]string{dbtools.FixtureSuperMicro.ID},
+			[]string{dbtools.FixtureSuperMicroX11DPHTBMC.ID},
 			false,
 			"",
 		},


### PR DESCRIPTION
This change extends the AttributeListParams to support an Attribute Operator such as - `and` `or`
to enable the client to define how multiple Attributes should be SQL queried.

This change is backwards compatible and defaults to `and` which is the previous behaviour.

The client can now query multiple attributes and specify which of them should looked up
with an OR, by including a `~` separated value - `or` in the `attr` query parameter.

For example, to query firmware sets with models `r6515` OR `r640`,

`/api/v1/server-component-firmware-sets?attr=sh.hollow.firmware_set.labels~model~eq~r6515&attr=sh.hollow.firmware_set.labels~model~eq~r640~or`