### PR TITLE
FS-899 Add bom router handlers and client APIs to fetch bom by bmcMacAddree

### DIFF
--- a/pkg/api/v1/bom.go
+++ b/pkg/api/v1/bom.go
@@ -27,6 +27,12 @@ type AocMacAddressBom struct {
 	SerialNum     string `json:"serial_num"`
 }
 
+// BmcMacAddressBom provides a struct to map the bmc_mac_address table.
+type BmcMacAddressBom struct {
+	BmcMacAddress string `json:"bmc_mac_address"`
+	SerialNum     string `json:"serial_num"`
+}
+
 // toDBModel converts Bom to BomInfo.
 func (b *Bom) toDBModel() (*models.BomInfo, error) {
 	if b.SerialNum == "" {
@@ -75,4 +81,24 @@ func (b *Bom) toAocMacAddressDBModels() ([]*models.AocMacAddress, error) {
 	}
 
 	return dbAs, nil
+}
+
+// toBmcMacAddressDBModels converts Bom to one or multiple BmcMacAddress.
+func (b *Bom) toBmcMacAddressDBModels() ([]*models.BMCMacAddress, error) {
+	if b.BmcMacAddress == "" {
+		return nil, errors.Errorf("the primary key bmc-mac-address can not be blank")
+	}
+
+	dbBs := []*models.BMCMacAddress{}
+
+	BmcMacAddrs := strings.Split(b.BmcMacAddress, ",")
+	for _, bmcMacAddr := range BmcMacAddrs {
+		dbB := &models.BMCMacAddress{
+			SerialNum:     b.SerialNum,
+			BMCMacAddress: bmcMacAddr,
+		}
+		dbBs = append(dbBs, dbB)
+	}
+
+	return dbBs, nil
 }

--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -137,7 +137,11 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 			srvBomByAocMacAddress.GET("/:aoc_mac_address", amw.RequiredScopes(readScopes("aoc-mac-address")), r.getBomFromAocMacAddress)
 		}
 
-		// TODO: support query by bmc-mac-address
+		// /bill-of-materials/bmc-mac-address
+		srvBomByBmcMacAddress := srvBoms.Group("/bmc-mac-address")
+		{
+			srvBomByBmcMacAddress.GET("/:bmc_mac_address", amw.RequiredScopes(readScopes("bmc-mac-address")), r.getBomFromBmcMacAddress)
+		}
 	}
 }
 

--- a/pkg/api/v1/server_service.go
+++ b/pkg/api/v1/server_service.go
@@ -21,6 +21,7 @@ const (
 	bomInfoEndpoint                     = "bill-of-materials"
 	uploadFileEndpoint                  = "batch-upload"
 	bomByMacAOCAddressEndpoint          = "aoc-mac-address"
+	bomByMacBMCAddressEndpoint          = "bmc-mac-address"
 )
 
 // ClientInterface provides an interface for the expected calls to interact with a server service api
@@ -59,6 +60,7 @@ type ClientInterface interface {
 	ListServerCredentialTypes(context.Context) (*ServerResponse, error)
 	BillOfMaterialsBatchUpload(context.Context, []Bom) (*ServerResponse, error)
 	GetBomInfoByAOCMacAddr(context.Context, string) (*Bom, *ServerResponse, error)
+	GetBomInfoByBMCMacAddr(context.Context, string) (*Bom, *ServerResponse, error)
 }
 
 // Create will attempt to create a server in Hollow and return the new server's UUID
@@ -403,6 +405,19 @@ func (c *Client) BillOfMaterialsBatchUpload(ctx context.Context, boms []Bom) (*S
 // GetBomInfoByAOCMacAddr will return the bom info object by the aoc mac address.
 func (c *Client) GetBomInfoByAOCMacAddr(ctx context.Context, aocMacAddr string) (*Bom, *ServerResponse, error) {
 	path := fmt.Sprintf("%s/%s/%s", bomInfoEndpoint, bomByMacAOCAddressEndpoint, aocMacAddr)
+	bom := &Bom{}
+	r := ServerResponse{Record: bom}
+
+	if err := c.get(ctx, path, &r); err != nil {
+		return nil, nil, err
+	}
+
+	return bom, &r, nil
+}
+
+// GetBomInfoByBMCMacAddr will return the bom info object by the bmc mac address.
+func (c *Client) GetBomInfoByBMCMacAddr(ctx context.Context, bmcMacAddr string) (*Bom, *ServerResponse, error) {
+	path := fmt.Sprintf("%s/%s/%s", bomInfoEndpoint, bomByMacBMCAddressEndpoint, bmcMacAddr)
 	bom := &Bom{}
 	r := ServerResponse{Record: bom}
 

--- a/pkg/api/v1/server_service_test.go
+++ b/pkg/api/v1/server_service_test.go
@@ -381,3 +381,19 @@ func TestGetBomInfoByAOCMacAddr(t *testing.T) {
 		return err
 	})
 }
+
+func TestGetBomInfoByBMCMacAddr(t *testing.T) {
+	mockClientTests(t, func(ctx context.Context, respCode int, expectError bool) error {
+		bom := hollow.Bom{SerialNum: "fakeSerialNum1", AocMacAddress: "fakeAocMacAddress1", BmcMacAddress: "fakeBmcMacAddress1"}
+		jsonResponse, err := json.Marshal(hollow.ServerResponse{Record: bom})
+		require.Nil(t, err)
+
+		c := mockClient(string(jsonResponse), respCode)
+		respBom, _, err := c.GetBomInfoByBMCMacAddr(ctx, "fakeBmcMacAddress1")
+		if !expectError {
+			assert.Equal(t, &bom, respBom)
+		}
+
+		return err
+	})
+}


### PR DESCRIPTION
This PR is a follow up from https://github.com/metal-toolbox/hollow-serverservice/pull/240

Adds a router handlers for receiving requests and processing Bom fetch(by BmcMacAddr): POST GET /bom-info/aoc-mac-address
Adds a client API for sending requests to ServerService to fetch Bom(by BmcMacAddr): GetBomInfoByBMCMacAddr.
Not able to resolve the test coverage warning since previous code can guarantee situation won't happen.
However it's still good to leave those checks there in case third party library changes their behavior silently.

Also tested with local serverservice + crdb.