### PR TITLE
Draft: Enable hard delete by param

### DIFF
--- a/pkg/api/v1/router.go
+++ b/pkg/api/v1/router.go
@@ -49,6 +49,7 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 			srv.GET("", amw.RequiredScopes(readScopes("server")), r.serverGet)
 			srv.PUT("", amw.RequiredScopes(updateScopes("server")), r.serverUpdate)
 			srv.DELETE("", amw.RequiredScopes(deleteScopes("server")), r.serverDelete)
+			srv.DELETE("/:hard-delete", amw.RequiredScopes(deleteScopes("server")), r.serverDelete)
 
 			// /servers/:uuid/attributes
 			srvAttrs := srv.Group("/attributes")

--- a/pkg/api/v1/router_server.go
+++ b/pkg/api/v1/router_server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/volatiletech/null/v8"
@@ -126,7 +127,8 @@ func (r *Router) serverDelete(c *gin.Context) {
 		return
 	}
 
-	if _, err = dbSRV.Delete(c.Request.Context(), r.DB, false); err != nil {
+	hardDelete, _ := strconv.ParseBool(c.Param("hard-delete"))
+	if _, err = dbSRV.Delete(c.Request.Context(), r.DB, hardDelete); err != nil {
 		dbErrorResponse(c, err)
 		return
 	}

--- a/pkg/api/v1/server_service.go
+++ b/pkg/api/v1/server_service.go
@@ -28,6 +28,7 @@ const (
 type ClientInterface interface {
 	Create(context.Context, Server) (*uuid.UUID, *ServerResponse, error)
 	Delete(context.Context, Server) (*ServerResponse, error)
+	DeleteNow(context.Context, Server) (*ServerResponse, error)
 	Get(context.Context, uuid.UUID) (*Server, *ServerResponse, error)
 	List(context.Context, *ServerListParams) ([]Server, *ServerResponse, error)
 	Update(context.Context, uuid.UUID, Server) (*ServerResponse, error)
@@ -78,9 +79,14 @@ func (c *Client) Create(ctx context.Context, srv Server) (*uuid.UUID, *ServerRes
 	return &u, resp, nil
 }
 
-// Delete will attempt to delete a server in Hollow and return an error on failure
+// Delete will attempt to soft delete a server in Hollow and return an error on failure
 func (c *Client) Delete(ctx context.Context, srv Server) (*ServerResponse, error) {
 	return c.delete(ctx, fmt.Sprintf("%s/%s", serversEndpoint, srv.UUID))
+}
+
+// DeleteNow will attempt to hard delete a server in Hollow and return an error on failure
+func (c *Client) DeleteNow(ctx context.Context, srv Server) (*ServerResponse, error) {
+	return c.delete(ctx, fmt.Sprintf("%s/%s/true", serversEndpoint, srv.UUID))
 }
 
 // Get will return a server by it's UUID


### PR DESCRIPTION
It looks like we already support hard-delete but it's disabled by default.

Maybe we can use param to enable hard-delete. Existing behavior remain unchanged if there is no param.